### PR TITLE
Correcting Example for Vault Username and Password Provider

### DIFF
--- a/ojdbc-provider-oci/example-vault.properties
+++ b/ojdbc-provider-oci/example-vault.properties
@@ -43,14 +43,14 @@
 # connection property. For details, see:
 # https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE
 
-# Configures the OCI Vault Password Provider. The OCID of the password secret
-# is configured as an environment variable or JVM system property named
-# "PASSWORD_OCID":
-oracle.jdbc.provider.user=ojdbc-provider-oci-vault-user
-oracle.jdbc.provider.user.ocid=${PASSWORD_OCID}
-
 # Configures the OCI Vault Username Provider. The OCID of the username secret
 # is configured as an environment variable or JVM system property named
 # "USERNAME_OCID":
-oracle.jdbc.provider.password=ojdbc-provider-oci-vault-user
-oracle.jdbc.provider.password.ocid=${USERNAME_OCID}
+oracle.jdbc.provider.username=ojdbc-provider-oci-vault-username
+oracle.jdbc.provider.username.ocid=${USERNAME_OCID}
+
+# Configures the OCI Vault Password Provider. The OCID of the password secret
+# is configured as an environment variable or JVM system property named
+# "PASSWORD_OCID":
+oracle.jdbc.provider.password=ojdbc-provider-oci-vault-password
+oracle.jdbc.provider.password.ocid=${PASSWORD_OCID}


### PR DESCRIPTION
The example connection properties file was just completely wrong. This branch corrects it.