### PR TITLE
Change type names of existing secret provider to "azurevault" and "ocivault"

### DIFF
--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureVaultSecretProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureVaultSecretProvider.java
@@ -65,7 +65,7 @@ public final class AzureVaultSecretProvider
    *   The {@code secretJsonObject} has the following form:
    * </p><pre>{@code
    *   "password": {
-   *       "type": "vault-azure",
+   *       "type": "azurevault",
    *       "value": "https://myvault.vault.azure.net/secrets/mysecret",
    *       "authentication": {
    *           "method": "AZURE_DEFAULT"
@@ -101,6 +101,6 @@ public final class AzureVaultSecretProvider
    */
   @Override
   public String getSecretType() {
-    return "vault-azure";
+    return "azurevault";
   }
 }

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureVaultSecretProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureVaultSecretProviderTest.java
@@ -50,7 +50,7 @@ import static oracle.jdbc.provider.TestProperties.getOrAbort;
 
 public class AzureVaultSecretProviderTest {
   private static final OracleConfigurationJsonSecretProvider PROVIDER =
-    OracleConfigurationJsonSecretProvider.find("vault-azure");
+    OracleConfigurationJsonSecretProvider.find("azurevault");
 
   /**
    * Verifies {@link OracleConfigurationJsonSecretProvider} as implementing
@@ -74,7 +74,7 @@ public class AzureVaultSecretProviderTest {
    * Returns a JSON object in following format:
    * <pre>
    * {
-   *   "type": "vault-azure",
+   *   "type": "azurevault",
    *   "value": "{"uri":"https://ojdbc-plugin-test-vault.vault.azure.net/secrets/test-db-password"}",
    *   "authentication": {
    *     "method": "AZURE_SERVICE_PRINCIPAL",
@@ -97,7 +97,7 @@ public class AzureVaultSecretProviderTest {
     auth.put("AZURE_TENANT_ID", tenantId);
 
     OracleJsonObject password = factory.createObject();
-    password.put("type", "vault-azure");
+    password.put("type", "azurevault");
     password.put("value", constructSecretUri(vaultUrl, secretName));
     password.put("authentication", auth);
 

--- a/ojdbc-provider-oci/README.md
+++ b/ojdbc-provider-oci/README.md
@@ -92,7 +92,7 @@ And the JSON Payload for the file **payload_ojdbc_objectstorage.json** in the **
   "connect_descriptor": "(description=(retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-phoenix-1.oraclecloud.com))(connect_data=(service_name=xsxsxs_dbtest_medium.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))",
   "user": "scott",
   "password": { 
-    "type": "vault-oci",
+    "type": "ocivault",
     "value": "ocid1.vaultsecret.oc1.phx.amaaaaaxxxx"
   },
   "jdbc": {
@@ -122,14 +122,14 @@ For the JSON type of provider (OCI Object Storage, HTTP/HTTPS, File) the passwor
 - type
   - Mandatory
   - Possible values
-    - vault-oci
-    - vault-azure
+    - ocivault
+    - azurevault
     - base64
 - value
   - Mandatory
   - Possible values
-    - OCID of the secret (if vault-oci)
-    - Azure Key Vault URI (if vault-azure)
+    - OCID of the secret (if ocivault)
+    - Azure Key Vault URI (if azurevault)
     - Base64 Encoded password (if base64)
     - Text
 - authentication

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciVaultSecretProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciVaultSecretProvider.java
@@ -58,7 +58,7 @@ public final class OciVaultSecretProvider
    *   The {@code secretJsonObject} has the following form:
    * </p><pre>{@code
    *   "password": {
-   *       "type": "vault-oci",
+   *       "type": "ocivault",
    *       "value": "ocid1.vaultsecret.oc1.phx.amaaaaaad...",
    *       "authentication": {
    *           "method": "OCI_DEFAULT"
@@ -90,6 +90,6 @@ public final class OciVaultSecretProvider
    */
   @Override
   public String getSecretType() {
-    return "vault-oci";
+    return "ocivault";
   }
 }


### PR DESCRIPTION
Type names of existing secret providers `AzureVaultSecretProvider` and ` OciVaultSecretProvider`, are changed.
Specifically, the type name of `AzureVaultSecretProvider` is changes from "vault-azure" to "azurevault".
The type name of ` OciVaultSecretProvider` is changed from "vault-oci" to "ocivault".

This change is for the consistency with the type names of the newly-added json providers ( `AzureVaultJsonProvider` and `OciVaultJsonProvider` ).

The type names are also changed in test accounts accordingly. So if you want to run the Github workflow recently, please git pull the latest changes or cherry-pick it from this branch, to make the workflow work. Thanks!

Please take a look.