### PR TITLE
updating doc for configuration cache

### DIFF
--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -7,6 +7,10 @@ This module contains providers for integration between Oracle JDBC and Azure.
 <dl>
 <dt><a href="#config-provider-for-azure">Config Provider for Azure</a></dt>
 <dd>Provides connection properties managed by the App Configuration service</dd>
+<dt><a href="#common-parameters-for-centralized-config-providers">Common Parameters for Centralized Config Providers</a></dt>
+<dd>Common parameters supported by the config providers</dd>
+<dt><a href="#caching-configuration">Caching configuration</a></dt>
+<dd>Caching mechanism adopted by Centralized Config Providers</dd>
 </dl>
 
 ## Resource Providers
@@ -18,6 +22,8 @@ This module contains providers for integration between Oracle JDBC and Azure.
 <dd>Provides a username from the Key Vault service</dd>
 <dt><a href="#key-vault-password-provider">Key Vault Password Provider</a></dt>
 <dd>Provides a password from the Key Vault service</dd>
+<dt><a href="#common-parameters-for-resource-providers">Common Parameters for Resource Providers</a></dt>
+<dd>Common parameters supported by the resource providers</dd>
 </dl>
 
 ## Installation
@@ -34,7 +40,7 @@ JDK versions. The coordinates for the latest release are:
 </dependency>
 ```
 
-## Config Provider for Azure
+## App Config Provider
 
 The Config Provider for Azure is a Centralized Config Provider that provides Oracle JDBC with
 connection properties from the App Configuration service and the Key Vault service.
@@ -85,6 +91,9 @@ The sample code below executes as expected with the previous configuration (and 
     if (rs.next())
       System.out.println("select sysdate from dual: " + rs.getString(1));
 ```
+
+## Common Parameters for Centralized Config Providers
+Provider that are classified as Centralized Config Providers in this module share the same sets of parameters for authentication configuration.
 
 ### Configuring Authentication
 
@@ -151,6 +160,40 @@ The Azure SDK `DefaultAzureCredential` class tries the following flow in order t
 - [AzureCliCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.azureclicredential?view=azure-dotnet)
 - [AzurePowerShellCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.azurepowershellcredential?view=azure-dotnet)
 - [InteractiveBrowserCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.interactivebrowsercredential?view=azure-dotnet)
+
+## Caching configuration
+
+Config providers in this module store the configuration in caches to minimize
+the number of RPC requests to remote location. Every stored items has a property
+that defines the time-to-live (TTL) value. When TTL expires, the configuration
+becomes "softly expired" and the stored configuration will be refreshed by a
+background thread. If configuration cannot be refreshed, it can still be used 
+for another 30 minutes until it becomes "hardly expired". In other words, it takes
+24 hours and 30 minutes for configuration before it becomes completely expired. 
+
+The default value of TTL is 24 hours and it can be configured using the
+"config_time_to_live" property in the unit of seconds.
+An example of App Configuration in Azure with TTL of 60 seconds is listed below.
+
+<table>
+<thead><tr>
+<th>Key</th>
+<th>Value</th>
+</tr></thead>
+<tbody><tr>
+<td>user</td>
+<td>myUsername</td>
+</tr><tr>
+<td>password</td>
+<td>myPassword</td>
+</tr><tr>
+<td>connect_descriptor</td>
+<td>myHost:5521/myService</td>
+</tr><tr>
+<td>config_time_to_live</td>
+<td>60</td>
+</tr></tbody>
+</table>
 
 ## Access Token Provider
 The Access Token Provider provides Oracle JDBC with an access token that authorizes 

--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -5,7 +5,7 @@ This module contains providers for integration between Oracle JDBC and Azure.
 ## Centralized Config Providers
 
 <dl>
-<dt><a href="#config-provider-for-azure">Config Provider for Azure</a></dt>
+<dt><a href="#azure-app-configuration-provider">Azure App Configuration Provider</a></dt>
 <dd>Provides connection properties managed by the App Configuration service</dd>
 <dt><a href="#common-parameters-for-centralized-config-providers">Common Parameters for Centralized Config Providers</a></dt>
 <dd>Common parameters supported by the config providers</dd>
@@ -40,7 +40,7 @@ JDK versions. The coordinates for the latest release are:
 </dependency>
 ```
 
-## App Config Provider
+## Azure App Configuration Provider
 
 The Config Provider for Azure is a Centralized Config Provider that provides Oracle JDBC with
 connection properties from the App Configuration service and the Key Vault service.

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProvider.java
@@ -130,14 +130,14 @@ public class AzureAppConfigurationProvider
         properties,
         configTimeToLive,
         () -> this.refreshProperties(location),
-          MS_REFRESH_TIMEOUT,
-          MS_RETRY_INTERVAL);
+        MS_REFRESH_TIMEOUT,
+        MS_RETRY_INTERVAL);
     } else {
       cache.put(location,
         properties,
         () -> this.refreshProperties(location),
-          MS_REFRESH_TIMEOUT,
-          MS_RETRY_INTERVAL);
+        MS_REFRESH_TIMEOUT,
+        MS_RETRY_INTERVAL);
     }
 
     return properties;

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureVaultJsonProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureVaultJsonProvider.java
@@ -44,7 +44,6 @@ import oracle.jdbc.provider.parameter.ParameterSet;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/ojdbc-provider-oci/README.md
+++ b/ojdbc-provider-oci/README.md
@@ -13,11 +13,15 @@ service</dd>
 <dt><a href="#oci-object-storage-config-provider">OCI Object Storage Config 
 Provider</a></dt>
 <dd>Provides connection properties managed by the Object Storage service</dd>
+<dt><a href="#common-parameters-for-centralized-config-providers">Common Parameters for Centralized Config Providers</a></dt>
+<dd>Common parameters supported by the config providers</dd>
+<dt><a href="#caching-configuration">Caching configuration</a></dt>
+<dd>Caching mechanism adopted by Centralized Config Providers</dd>
 </dl>
-<dl>
 
 ## Resource Providers
 
+<dl>
 <dt><a href="#database-connection-string-provider">Database Connection String Provider</a></dt>
 <dd>Provides connection strings for an Autonomous Database</dd>
 <dt><a href="#database-tls-provider">Database TLS Provider</a></dt>
@@ -28,7 +32,10 @@ Provider</a></dt>
 <dd>Provides usernames managed by the Vault service</dd>
 <dt><a href="#access-token-provider">Access Token Provider</a></dt>
 <dd>Provides access tokens issued by the Dataplane service</dd>
+<dt><a href="#common-parameters-for-resource-providers">Common Parameters for Resource Providers</a></dt>
+<dd>Common parameters supported by the resource providers</dd>
 </dl>
+
 Visit any of the links above to find information and usage examples for a
 particular provider.
 
@@ -195,6 +202,13 @@ in Optional Parameters</td>
 </table>
 
 <i>*Note: this parameter is introduced to align with entries of the config file. The region that is used for calling Object Storage, Database Tools Connection, and Secret services will be extracted from the Object Storage URL, Database Tools Connection OCID or Secret OCID</i>
+
+## Caching configuration
+
+Config providers in this module store the configuration in caches to minimize
+the number of RPC requests to remote location. See
+[Caching configuration](../ojdbc-provider-azure/README.md#caching-configuration) for more 
+details of the caching mechanism.
 
 ## Database Connection String Provider
 The Database Connection String Provider provides Oracle JDBC with the connection string of an

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
@@ -79,14 +79,14 @@ public class OciDatabaseToolsConnectionProvider
         properties,
         configTimeToLive,
         () -> this.refreshProperties(location),
-          MS_REFRESH_TIMEOUT,
-          MS_RETRY_INTERVAL);
+        MS_REFRESH_TIMEOUT,
+        MS_RETRY_INTERVAL);
     } else {
       cache.put(location,
         properties,
         () -> this.refreshProperties(location),
-          MS_REFRESH_TIMEOUT,
-          MS_RETRY_INTERVAL);
+        MS_REFRESH_TIMEOUT,
+        MS_RETRY_INTERVAL);
     }
 
     return properties;

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
@@ -28,15 +28,30 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 
+/**
+ * <p>
+ *   A provider of configuration from OCI Database Tools Connection.
+ * </p>
+ */
 public class OciDatabaseToolsConnectionProvider
     implements OracleConfigurationProvider {
 
   private static final String CONFIG_TIME_TO_LIVE =
     "config_time_to_live";
-  private static final long MS_TIMEOUT = 60_000L;
-  private static final long MS_REFRESH_INTERVAL = 60_000L;
+  /**
+   * Timeout value of the background thread that requests the configuration from
+   * remote location during soft-expiration period. The task will be interrupted
+   * after 60 seconds.
+   */
+  private static final long MS_REFRESH_TIMEOUT = 60_000L;
+  /**
+   * Retry interval of the background thread that requests the configuration
+   * from remote location during soft-expiration period. The thread will retry
+   * in a frequency of 60 seconds if the remote location is unreachable.
+   */
+  private static final long MS_RETRY_INTERVAL = 60_000L;
 
-  private final OracleConfigurationCache cache = OracleConfigurationCache
+  private static final OracleConfigurationCache cache = OracleConfigurationCache
     .create(100);
 
   private ParameterSet commonParameters;
@@ -64,14 +79,14 @@ public class OciDatabaseToolsConnectionProvider
         properties,
         configTimeToLive,
         () -> this.refreshProperties(location),
-        MS_TIMEOUT,
-        MS_REFRESH_INTERVAL);
+          MS_REFRESH_TIMEOUT,
+          MS_RETRY_INTERVAL);
     } else {
       cache.put(location,
         properties,
         () -> this.refreshProperties(location),
-        MS_TIMEOUT,
-        MS_REFRESH_INTERVAL);
+          MS_REFRESH_TIMEOUT,
+          MS_RETRY_INTERVAL);
     }
 
     return properties;


### PR DESCRIPTION
Update README.mds to add more contents for the caching of configuration. Renaming the constants `MS_TIMEOUT` and `MS_REFRESH_INTERVAL` add adding javadoc to be more descriptive. 

I've also made minor changes in the README.mds. You can compare the difference by clicking "Display the rich diff" besides the three dots icon. Please let me know if you have any thoughts on the changes. Thanks.