### PR TITLE
Stronger Verification for Azure Credential Factory test

### DIFF
--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/authentication/TokenCredentialFactoryTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/authentication/TokenCredentialFactoryTest.java
@@ -38,7 +38,9 @@
 
 package oracle.jdbc.provider.azure.authentication;
 
+import com.azure.core.credential.AccessToken;
 import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
 import com.azure.core.util.Configuration;
 import oracle.jdbc.provider.TestProperties;
 import oracle.jdbc.provider.azure.AzureTestProperty;
@@ -48,6 +50,7 @@ import oracle.jdbc.provider.parameter.ParameterSetBuilder;
 import org.junit.jupiter.api.Test;
 
 import static oracle.jdbc.provider.TestProperties.getOrAbort;
+import static oracle.jdbc.provider.azure.AzureTestProperty.AZURE_TOKEN_SCOPE;
 import static oracle.jdbc.provider.azure.authentication.AzureAuthenticationMethod.*;
 import static oracle.jdbc.provider.azure.authentication.TokenCredentialFactory.AUTHENTICATION_METHOD;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -246,6 +249,8 @@ public class TokenCredentialFactoryTest {
 
   /** Verifies the TokenCredential created for a given set of parameters */
   private static void verifyTokenCredential(ParameterSet parameterSet) {
+    String tokenScope = getOrAbort(AZURE_TOKEN_SCOPE);
+
     Resource<TokenCredential> tokenResource =
       TokenCredentialFactory.getInstance()
         .request(parameterSet);
@@ -255,9 +260,14 @@ public class TokenCredentialFactoryTest {
     assertTrue(tokenResource.isValid());
 
     TokenCredential tokenCredential = tokenResource.getContent();
-
-    // TODO: Add additional verifications if possible
     assertNotNull(tokenCredential);
+
+    TokenRequestContext tokenRequestContext =
+      new TokenRequestContext().addScopes(tokenScope);
+    AccessToken accessToken =
+      tokenCredential.getToken(tokenRequestContext)
+        .block();
+    assertNotNull(accessToken);
   }
 
 }


### PR DESCRIPTION
The test for TokenCredentialFactory will now invoke `getToken()` on the `TokenCredential`. This will light up some additional Azure SDK code, and catch defects like this: https://github.com/Azure/azure-sdk-for-java/pull/39002

The defect linked to above will cause AZURE_DEFAULT/auto-detect authentication to fail when a `AZURE_CLIENT_SECRET` and `AZURE_CLIENT_CERTIFICATE` are not configured. Users may hit this when attempting to use `AZURE_USERNAME` and `AZURE_PASSWORD` for authentication.

Users can work around this by pulling in the latest azure-identity module in their own pom.xml:
```xml
    <dependency>
      <groupId>com.azure</groupId>
      <artifactId>azure-identity</artifactId>
      <version>1.12.1</version>
    </dependency>
```