### PR TITLE
Upgrade to the latest version of azure-bom-sdk

### DIFF
--- a/ojdbc-provider-azure/pom.xml
+++ b/ojdbc-provider-azure/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-sdk-bom</artifactId>
-        <version>1.2.19</version>
+        <version>1.2.24</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Using AZURE_DEFAULT authentication with AZURE_USERNAME and AZURE_PASSWORD failed to acquire token. This is a defect in our `azure-identity` dependency. Upgrading to the latest `azure-bom-sdk` of version 1.2.24 fixes the issue.