### PR TITLE
Added a provider for GCP

### DIFF
--- a/ojdbc-provider-gcp/README.md
+++ b/ojdbc-provider-gcp/README.md
@@ -1,0 +1,203 @@
+# Oracle JDBC Providers for GCP
+
+This module contains providers for integration between Oracle JDBC and
+Google Cloud Platform (GCP).
+
+## Centralized Config Providers
+
+<dl>
+<dt><a href="#gcp-object-storage-config-provider">GCP Object Storage Config 
+Provider</a></dt>
+<dd>Provides connection properties managed by the Object Storage service</dd>
+<dt><a href="#gcp-vault-secret-config-provider">GCP Vault Secret Config Provider</a></dt>
+<dd>Provides connection properties managed by the Secret Manager service</dd>
+<dt><a href="#common-parameters-for-centralized-config-providers">Common Parameters for Centralized Config Providers</a></dt>
+<dd>Common parameters supported by the config providers</dd>
+<dt><a href="#caching-configuration">Caching configuration</a></dt>
+<dd>Caching mechanism adopted by Centralized Config Providers</dd>
+</dl>
+
+## Resource Providers
+
+<dl>
+<dt><a href="#vault-password-provider">Vault Password Provider</a></dt>
+<dd>Provides passwords managed by the Vault service</dd>
+<dt><a href="#vault-username-provider">Vault Username Provider</a></dt>
+<dd>Provides usernames managed by the Vault service</dd>
+<dt><a href="#common-parameters-for-resource-providers">Common Parameters for Resource Providers</a></dt>
+<dd>Common parameters supported by the resource providers</dd>
+</dl>
+
+Visit any of the links above to find information and usage examples for a
+particular provider.
+
+## Installation
+
+All providers in this module are distributed as single jar on the Maven Central
+Repository. The jar is compiled for JDK 8, and is forward compatible with later
+JDK versions. The coordinates for the latest release are:
+```xml
+<dependency>
+  <groupId>com.oracle.database.jdbc</groupId>
+  <artifactId>ojdbc-provider-gcp</artifactId>
+  <version>1.0.1</version>
+</dependency>
+```
+
+## GCP Object Storage Config Provider
+The Oracle DataSource uses a new prefix `jdbc:oracle:thin:@config-gcp-object:` to be able to identify that the configuration parameters should be loaded using GCP Object Storage. Users only need to indicate the project, bucket and object containing the JSON payload, with the following syntax:
+
+<pre>
+jdbc:oracle:thin:@config-gcp-object://project={project};bucket={bucket};object={object}]
+</pre>
+
+### JSON Payload format
+
+There are 3 fixed values that are looked at the root level.
+
+- connect_descriptor (required)
+- user (optional)
+- password (optional)
+
+The rest are dependent on the driver, in our case `/jdbc`. The key-value pairs that are with sub-prefix `/jdbc` will be applied to a DataSource. The key values are constant keys which are equivalent to the properties defined in the [OracleConnection](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html) interface.
+
+For example, let's suppose an url like:
+
+<pre>
+jdbc:oracle:thin:@config-gcpobject://project=myproject;bucket=mybucket;object=payload_ojdbc_objectstorage.json
+</pre>
+
+And the JSON Payload for the file **payload_ojdbc_objectstorage.json** in the **mybucket** which belongs to the project **myproject** is as following:
+
+```json
+{
+  "connect_descriptor": "(description=(retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-phoenix-1.oraclecloud.com))(connect_data=(service_name=xsxsxs_dbtest_medium.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))",
+  "user": "scott",
+  "password": { 
+    "type": "gcpsecret",
+    "value": "projects/138028249883/secrets/test-secret/versions/1"
+  },
+  "jdbc": {
+    "oracle.jdbc.ReadTimeout": 1000,
+    "defaultRowPrefetch": 20,
+    "autoCommit": "false"
+  }
+}
+```
+
+The sample code below executes as expected with the previous configuration.
+
+```java
+    OracleDataSource ds = new OracleDataSource();
+    ds.setURL("jdbc:oracle:thin:@config-gcpobject://project=myproject;bucket=mybucket;object=payload_ojdbc_objectstorage.json");
+    Connection cn = ds.getConnection();
+    Statement st = cn.createStatement();
+    ResultSet rs = st.executeQuery("select sysdate from dual");
+    if (rs.next())
+      System.out.println("select sysdate from dual: " + rs.getString(1));
+```
+
+### Password JSON Object
+
+For the JSON type of provider (GCP Object Storage, HTTP/HTTPS, File) the password is an object itself with the following spec:
+
+- type
+  - Mandatory
+  - Possible values
+    - ocivault
+    - azurevault
+    - base64
+    - gcpsecret
+- value
+  - Mandatory
+  - Possible values
+    - OCID of the secret (if ocivault)
+    - Azure Key Vault URI (if azurevault)
+    - Base64 Encoded password (if base64)
+    - GCP resource name (if gcpsecret)
+    - Text
+- authentication
+  - Optional
+  - Possible Values
+    - method
+    - optional parameters (depends on the cloud provider).
+
+## GCP Vault Secret Config Provider
+Apart from GCP Object Storage, users can also store JSON Payload in the content of GCP Secret Manager secret. Users need to indicate the resource name:
+
+<pre>
+jdbc:oracle:thin:@config-gcpvault:{resource-name}
+</pre>
+
+The JSON Payload retrieved by GCP Vault Config Provider follows the same format in [GCP Object Storage Config Provider](#json-payload-format).
+
+## Caching configuration
+
+Config providers in this module store the configuration in caches to minimize
+the number of RPC requests to remote location. See
+[Caching configuration](../ojdbc-provider-azure/README.md#caching-configuration) for more 
+details of the caching mechanism.
+
+## Vault Password Provider
+The Vault Password Provider provides Oracle JDBC with a password that is managed
+by the GCP Secret Manager service. This is a Resource Provider identified by the
+name `ojdbc-provider-gcp-secret-password`.
+
+This provider requires the parameters listed below.
+<table>
+<thead><tr>
+<th>Parameter Name</th>
+<th>Description</th>
+<th>Accepted Values</th>
+<th>Default Value</th>
+</tr></thead>
+<tbody><tr>
+<td>secretVersionName</td>
+<td>Identifies the secret that is provided.</td>
+<td>The resource name of the secret.</td>
+<td><i>No default value. A value must be configured for this parameter.</i></td>
+</tr></tbody>
+</table>
+
+An example of a
+[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
+that configures this provider can be found in
+[example-vault.properties](example-vault.properties).
+
+## Vault Username Provider
+The Vault Username Provider provides Oracle JDBC with a username that is managed by the
+GCP Secret Manager service. This is a Resource Provider identified by the name
+`ojdbc-provider-gcp-secret-username`.
+
+In addition to the set of [common parameters](#common-parameters-for-resource-providers), this provider
+also supports the parameters listed below.
+<table>
+<thead><tr>
+<th>Parameter Name</th>
+<th>Description</th>
+<th>Accepted Values</th>
+<th>Default Value</th>
+</tr></thead>
+<tbody><tr>
+<td>secretVersionName</td>
+<td>Identifies the secret that is provided.</td>
+<td>The resource name of the secret.</td>
+<td><i>No default value. A value must be configured for this parameter.</i></td>
+</tr></tbody>
+</table>
+
+An example of a
+[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
+that configures this provider can be found in
+[example-vault.properties](example-vault.properties).
+
+## Configuring Authentication
+
+Providers use Google Cloud APIs which support 
+[Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials); 
+the libraries look for credentials in a set of defined locations and use those 
+credentials to authenticate requests to the API.
+
+
+
+

--- a/ojdbc-provider-gcp/README.md
+++ b/ojdbc-provider-gcp/README.md
@@ -198,6 +198,12 @@ Providers use Google Cloud APIs which support
 the libraries look for credentials in a set of defined locations and use those 
 credentials to authenticate requests to the API.
 
+ADC searches for credentials in the following locations:
+
+1. GOOGLE_APPLICATION_CREDENTIALS environment variable
+2. User credentials set up by using the Google Cloud CLI
+3. The attached service account, returned by the metadata server
+
 When your code is running in a local development environment, such as a development workstation, the best option is to use the credentials associated with your user 
 account.
 

--- a/ojdbc-provider-gcp/README.md
+++ b/ojdbc-provider-gcp/README.md
@@ -201,7 +201,7 @@ credentials to authenticate requests to the API.
 When your code is running in a local development environment, such as a development workstation, the best option is to use the credentials associated with your user 
 account.
 
-###Configure ADC with your Google Account
+### Configure ADC with your Google Account
 To configure ADC with a Google Account, you use the Google Cloud CLI:
 
 1. Install and initialize the gcloud CLI.

--- a/ojdbc-provider-gcp/README.md
+++ b/ojdbc-provider-gcp/README.md
@@ -53,8 +53,7 @@ ADC searches for credentials in the following locations:
 2. User credentials set up by using the Google Cloud CLI
 3. The attached service account, returned by the metadata server
 
-When your code is running in a local development environment, such as a development workstation, the best option is to use the credentials associated with your user 
-account.
+When your code is running in a local development environment, such as a development workstation, the best option is to use the credentials associated with your user account.
 
 ### Configure ADC with your Google Account
 To configure ADC with a Google Account, you use the Google Cloud CLI:

--- a/ojdbc-provider-gcp/README.md
+++ b/ojdbc-provider-gcp/README.md
@@ -64,7 +64,7 @@ The rest are dependent on the driver, in our case `/jdbc`. The key-value pairs t
 For example, let's suppose an url like:
 
 <pre>
-jdbc:oracle:thin:@config-gcpobject://project=myproject;bucket=mybucket;object=payload_ojdbc_objectstorage.json
+jdbc:oracle:thin:@config-gcpstorage://project=myproject;bucket=mybucket;object=payload_ojdbc_objectstorage.json
 </pre>
 
 And the JSON Payload for the file **payload_ojdbc_objectstorage.json** in the **mybucket** which belongs to the project **myproject** is as following:
@@ -198,6 +198,19 @@ Providers use Google Cloud APIs which support
 the libraries look for credentials in a set of defined locations and use those 
 credentials to authenticate requests to the API.
 
+When your code is running in a local development environment, such as a development workstation, the best option is to use the credentials associated with your user 
+account.
 
+###Configure ADC with your Google Account
+To configure ADC with a Google Account, you use the Google Cloud CLI:
 
+1. Install and initialize the gcloud CLI.
+
+When you initialize the gcloud CLI, be sure to specify a Google Cloud project in which you have permission to access the resources your application needs.
+
+2. Configure ADC:
+```
+gcloud auth application-default login
+```
+A sign-in screen appears. After you sign in, your credentials are stored in the local credential file used by ADC.
 

--- a/ojdbc-provider-gcp/README.md
+++ b/ojdbc-provider-gcp/README.md
@@ -11,8 +11,6 @@ Provider</a></dt>
 <dd>Provides connection properties managed by the Object Storage service</dd>
 <dt><a href="#gcp-vault-secret-config-provider">GCP Vault Secret Config Provider</a></dt>
 <dd>Provides connection properties managed by the Secret Manager service</dd>
-<dt><a href="#common-parameters-for-centralized-config-providers">Common Parameters for Centralized Config Providers</a></dt>
-<dd>Common parameters supported by the config providers</dd>
 <dt><a href="#caching-configuration">Caching configuration</a></dt>
 <dd>Caching mechanism adopted by Centralized Config Providers</dd>
 </dl>
@@ -24,8 +22,6 @@ Provider</a></dt>
 <dd>Provides passwords managed by the Vault service</dd>
 <dt><a href="#vault-username-provider">Vault Username Provider</a></dt>
 <dd>Provides usernames managed by the Vault service</dd>
-<dt><a href="#common-parameters-for-resource-providers">Common Parameters for Resource Providers</a></dt>
-<dd>Common parameters supported by the resource providers</dd>
 </dl>
 
 Visit any of the links above to find information and usage examples for a
@@ -43,6 +39,35 @@ JDK versions. The coordinates for the latest release are:
   <version>1.0.1</version>
 </dependency>
 ```
+
+## Authentication
+
+Providers use Google Cloud APIs which support 
+[Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials); 
+the libraries look for credentials in a set of defined locations and use those 
+credentials to authenticate requests to the API.
+
+ADC searches for credentials in the following locations:
+
+1. GOOGLE_APPLICATION_CREDENTIALS environment variable
+2. User credentials set up by using the Google Cloud CLI
+3. The attached service account, returned by the metadata server
+
+When your code is running in a local development environment, such as a development workstation, the best option is to use the credentials associated with your user 
+account.
+
+### Configure ADC with your Google Account
+To configure ADC with a Google Account, you use the Google Cloud CLI:
+
+1. Install and initialize the gcloud CLI.
+
+When you initialize the gcloud CLI, be sure to specify a Google Cloud project in which you have permission to access the resources your application needs.
+
+2. Configure ADC:
+```
+gcloud auth application-default login
+```
+A sign-in screen appears. After you sign in, your credentials are stored in the local credential file used by ADC.
 
 ## GCP Object Storage Config Provider
 The Oracle DataSource uses a new prefix `jdbc:oracle:thin:@config-gcp-object:` to be able to identify that the configuration parameters should be loaded using GCP Object Storage. Users only need to indicate the project, bucket and object containing the JSON payload, with the following syntax:
@@ -191,32 +216,4 @@ An example of a
 that configures this provider can be found in
 [example-vault.properties](example-vault.properties).
 
-## Configuring Authentication
-
-Providers use Google Cloud APIs which support 
-[Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials); 
-the libraries look for credentials in a set of defined locations and use those 
-credentials to authenticate requests to the API.
-
-ADC searches for credentials in the following locations:
-
-1. GOOGLE_APPLICATION_CREDENTIALS environment variable
-2. User credentials set up by using the Google Cloud CLI
-3. The attached service account, returned by the metadata server
-
-When your code is running in a local development environment, such as a development workstation, the best option is to use the credentials associated with your user 
-account.
-
-### Configure ADC with your Google Account
-To configure ADC with a Google Account, you use the Google Cloud CLI:
-
-1. Install and initialize the gcloud CLI.
-
-When you initialize the gcloud CLI, be sure to specify a Google Cloud project in which you have permission to access the resources your application needs.
-
-2. Configure ADC:
-```
-gcloud auth application-default login
-```
-A sign-in screen appears. After you sign in, your credentials are stored in the local credential file used by ADC.
 

--- a/ojdbc-provider-gcp/example-vault.properties
+++ b/ojdbc-provider-gcp/example-vault.properties
@@ -1,0 +1,56 @@
+################################################################################
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or data
+# (collectively the "Software"), free of charge and under any and all copyright
+# rights in the Software, and any and all patent rights owned or freely
+# licensable by each licensor hereunder covering either (i) the unmodified
+# Software as contributed to or provided by such licensor, or (ii) the Larger
+# Works (as defined below), to deal in both
+#
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software (each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition:
+# The above copyright notice and either this complete permission notice or at
+# a minimum a reference to the UPL must be included in all copies or
+# substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+################################################################################
+
+# An example of a connection properties file that configures Oracle JDBC to
+# obtain a username and password from OCI's Vault Service.
+#
+# This file can be located by Oracle JDBC using the "oracle.jdbc.config.file"
+# connection property. For details, see:
+# https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE
+
+# Configures the GCP Vault Secret Username Provider. The resurce name of the 
+# username secret is configured as an environment variable or JVM system 
+# property named "USERNAME_SECRET_VERSION_NAME":
+oracle.jdbc.provider.username=ojdbc-provider-gcp-secret-username
+oracle.jdbc.provider.username.secretVersionName=${USERNAME_SECRET_VERSION_NAME}
+
+# Configures the OCI Vault Secret Password Provider. The resource name of the 
+# password secret is configured as an environment variable or JVM system 
+# property named "PASSWORD_SECRET_VERSION_NAME":
+oracle.jdbc.provider.password=ojdbc-provider-gcp-secret-password
+oracle.jdbc.provider.password.secretVersionName=${PASSWORD_SECRET_VERSION_NAME}

--- a/ojdbc-provider-gcp/pom.xml
+++ b/ojdbc-provider-gcp/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>Oracle JDBC GCP Providers</name>
+
+  <artifactId>ojdbc-provider-gcp</artifactId>
+  <version>1.0.1</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>com.oracle.database.jdbc</groupId>
+    <artifactId>ojdbc-extensions</artifactId>
+    <version>1.0.1</version>
+  </parent>
+
+  <properties>
+    <gcp-api-version>26.40.0</gcp-api-version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>${gcp-api-version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc-provider-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc8</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-secretmanager</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+    </dependency>
+    <!-- TEST DEPENDENCIES -->
+
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc-provider-common</artifactId>
+      <classifier>tests</classifier>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc-provider-common</artifactId>
+      <classifier>tests</classifier>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpConfigurationParameters.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpConfigurationParameters.java
@@ -63,8 +63,9 @@ public class GcpConfigurationParameters {
 
   /**
    * @return A parser that recognizes parameters of URIs received by
-   *         {@link OciObjectStorageProvider}, and JSON objects received by
-   *         {@link GcpVaultSecretProvider}.
+   *         {@link GcpObjectStorageConfigurationProvider}, and JSON objects
+   *         received by
+   *         {@link GcpVaultSecretConfigurationProvider}.
    */
   public static ParameterSetParser getParser() {
     return PARAMETER_SET_PARSER;

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpConfigurationParameters.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpConfigurationParameters.java
@@ -1,0 +1,72 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.jdbc.provider.gcp.configuration;
+
+import static oracle.jdbc.provider.gcp.secrets.GcpVaultSecretFactory.SECRET_VERSION_NAME;
+
+import oracle.jdbc.provider.gcp.objectstorage.GcpObjectStorageFactory;
+import oracle.jdbc.provider.parameter.ParameterSetParser;;
+
+public class GcpConfigurationParameters {
+  /**
+   * <p>
+   * A parser that recognizes parameters of URIs received by
+   * {@link GcpObjectStorageProvider}, and JSON objects received by
+   * {@link GcpVaultSecretProvider}.
+   * </p>
+   */
+  private static final ParameterSetParser PARAMETER_SET_PARSER = ParameterSetParser.builder()
+      .addParameter("value", SECRET_VERSION_NAME)
+      .addParameter("secretVersionName", SECRET_VERSION_NAME)
+      .addParameter(
+          GcpObjectStorageConfigurationProvider.PROJECT_PARAMETER, GcpObjectStorageFactory.PROJECT)
+      .addParameter(
+          GcpObjectStorageConfigurationProvider.BUCKET_PARAMETER, GcpObjectStorageFactory.BUCKET)
+      .addParameter(
+          GcpObjectStorageConfigurationProvider.OBJECT_PARAMETER, GcpObjectStorageFactory.OBJECT)
+      .build();
+
+  /**
+   * @return A parser that recognizes parameters of URIs received by
+   *         {@link OciObjectStorageProvider}, and JSON objects received by
+   *         {@link GcpVaultSecretProvider}.
+   */
+  public static ParameterSetParser getParser() {
+    return PARAMETER_SET_PARSER;
+  }
+}

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpJsonVaultSecretProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpJsonVaultSecretProvider.java
@@ -55,7 +55,7 @@ public class GcpJsonVaultSecretProvider implements OracleConfigurationJsonSecret
    * Returns the password of the Secret that is retrieved from GCP Secrets.
    * </p>
    * <p>
-   * The {@code secretJsonObject} has the following form:
+   * The {@code jsonObject} has the following form:
    * </p>
    * 
    * <pre>{@code
@@ -65,14 +65,14 @@ public class GcpJsonVaultSecretProvider implements OracleConfigurationJsonSecret
    *   }
    * }</pre>
    *
-   * @param secretJsonObject json object to be parsed
+   * @param jsonObject json object to be parsed
    * @return encoded char array in base64 format that represents the retrieved
    *         Secret.
    */
   @Override
-  public char[] getSecret(OracleJsonObject oracleJsonObject) {
+  public char[] getSecret(OracleJsonObject jsonObject) {
     ParameterSet parameterSet = GcpConfigurationParameters.getParser().parseNamedValues(
-        JsonSecretUtil.toNamedValues(oracleJsonObject));
+        JsonSecretUtil.toNamedValues(jsonObject));
 
     ByteString stringData = GcpVaultSecretFactory.getInstance().request(parameterSet).getContent().getData();
     return Base64.getEncoder().encodeToString(stringData.toByteArray()).toCharArray();

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpJsonVaultSecretProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpJsonVaultSecretProvider.java
@@ -1,0 +1,85 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.jdbc.provider.gcp.configuration;
+
+import com.google.protobuf.ByteString;
+
+import java.util.Base64;
+
+import oracle.jdbc.provider.configuration.JsonSecretUtil;
+import oracle.jdbc.provider.gcp.secrets.GcpVaultSecretFactory;
+import oracle.jdbc.provider.parameter.ParameterSet;
+import oracle.jdbc.spi.OracleConfigurationJsonSecretProvider;
+import oracle.sql.json.OracleJsonObject;
+
+public class GcpJsonVaultSecretProvider implements OracleConfigurationJsonSecretProvider {
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Returns the password of the Secret that is retrieved from GCP Secrets.
+   * </p>
+   * <p>
+   * The {@code secretJsonObject} has the following form:
+   * </p>
+   * 
+   * <pre>{@code
+   *   "password": {
+  *       "type": "gcpsecret",
+  *       "value": "projects/<project_name>/secrets/<secret_name>/versions/<version>",
+   *   }
+   * }</pre>
+   *
+   * @param secretJsonObject json object to be parsed
+   * @return encoded char array in base64 format that represents the retrieved
+   *         Secret.
+   */
+  @Override
+  public char[] getSecret(OracleJsonObject oracleJsonObject) {
+    ParameterSet parameterSet = GcpConfigurationParameters.getParser().parseNamedValues(
+        JsonSecretUtil.toNamedValues(oracleJsonObject));
+
+    ByteString stringData = GcpVaultSecretFactory.getInstance().request(parameterSet).getContent().getData();
+    return Base64.getEncoder().encodeToString(stringData.toByteArray()).toCharArray();
+  }
+
+  @Override
+  public String getSecretType() {
+    return "gcpsecret";
+  }
+}

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpObjectStorageConfigurationProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpObjectStorageConfigurationProvider.java
@@ -58,7 +58,7 @@ public class GcpObjectStorageConfigurationProvider extends OracleConfigurationJs
 
   @Override
   public String getType() {
-    return "gcpobject";
+    return "gcpstorage";
   }
 
   /**

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpObjectStorageConfigurationProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpObjectStorageConfigurationProvider.java
@@ -1,0 +1,95 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.jdbc.provider.gcp.configuration;
+
+import java.io.InputStream;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import oracle.jdbc.driver.OracleConfigurationJsonProvider;
+import oracle.jdbc.provider.gcp.objectstorage.GcpObjectStorageFactory;
+import oracle.jdbc.provider.parameter.ParameterSet;
+
+/**
+ * A provider for JSON payload which contains configuration from GCP Object
+ * Storage. See {@link #getJson(String)} for the spec of the JSON payload.
+ */
+public class GcpObjectStorageConfigurationProvider extends OracleConfigurationJsonProvider {
+
+  public static final String PROJECT_PARAMETER = "project";
+  public static final String BUCKET_PARAMETER = "bucket";
+  public static final String OBJECT_PARAMETER = "object";
+
+  @Override
+  public String getType() {
+    return "gcpobject";
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Returns the JSON payload stored in GCP Object Storage.
+   * </p>
+   * 
+   * @param location semi-colon separated list of key value pairs
+   *                 containing the following keys:
+   *                 <ul>
+   *                 <li>project: the project id</li>
+   *                 <li>bucket: the bucket containing the json configuration
+   *                 file</li>
+   *                 <li>object: the name of the json configuration file</li>
+   *                 </ul>
+   *                 Unknown keys will be ignored.
+   *                 Ex: project=myProject;bucket=myBucket;object=myfile.json
+   * @return JSON payload
+   */
+  @Override
+  public InputStream getJson(String location) throws SQLException {
+    Map<String, String> namedValues = new HashMap<>();
+    String[] keyValuePairs = location.split(";");
+    for (String keyValuePair : keyValuePairs) {
+      String[] keyValue = keyValuePair.split("=", 2);
+      namedValues.putIfAbsent(keyValue[0], keyValue[1]);
+    }
+    ParameterSet parameterSet = GcpConfigurationParameters.getParser().parseNamedValues(namedValues);
+
+    return GcpObjectStorageFactory.getInstance().request(parameterSet).getContent();
+  }
+
+}

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpVaultSecretConfigurationProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpVaultSecretConfigurationProvider.java
@@ -1,0 +1,81 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.jdbc.provider.gcp.configuration;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import oracle.jdbc.driver.OracleConfigurationJsonProvider;
+import oracle.jdbc.provider.gcp.secrets.GcpVaultSecretFactory;
+import oracle.jdbc.provider.parameter.ParameterSet;
+
+/**
+ * A provider for JSON payload which contains configuration from GCP Secret
+ * Manager.
+ * See {@link #getJson(String)} for the spec of the JSON payload.
+ **/
+public class GcpVaultSecretConfigurationProvider extends OracleConfigurationJsonProvider {
+
+  @Override
+  public String getType() {
+    return "gcpsecret";
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Returns the JSON payload stored in GCP Secret Manager secret.
+   * </p>
+   * 
+   * @param location resource name of the secret version (to obtain the resource
+   *                 name, click on "Actions" and "Copy resource name")
+   * @return JSON payload
+   */
+  @Override
+  public InputStream getJson(String location) throws SQLException {
+    Map<String, String> namedValues = new HashMap<>();
+    namedValues.put("secretVersionName", location);
+    ParameterSet parameterSet = GcpConfigurationParameters.getParser().parseNamedValues(namedValues);
+    return new ByteArrayInputStream(
+        GcpVaultSecretFactory.getInstance().request(parameterSet).getContent().getData().toByteArray());
+  }
+
+}

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/objectstorage/GcpObjectStorageFactory.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/objectstorage/GcpObjectStorageFactory.java
@@ -1,0 +1,86 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.jdbc.provider.gcp.objectstorage;
+
+import static oracle.jdbc.provider.parameter.Parameter.CommonAttribute.REQUIRED;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+
+import oracle.jdbc.provider.cache.CachedResourceFactory;
+import oracle.jdbc.provider.factory.Resource;
+import oracle.jdbc.provider.factory.ResourceFactory;
+import oracle.jdbc.provider.parameter.Parameter;
+import oracle.jdbc.provider.parameter.ParameterSet;
+
+public class GcpObjectStorageFactory implements ResourceFactory<InputStream> {
+  /** The secret version name for the secret */
+  public static final Parameter<String> PROJECT = Parameter.create(REQUIRED);
+  public static final Parameter<String> BUCKET = Parameter.create(REQUIRED);
+  public static final Parameter<String> OBJECT = Parameter.create(REQUIRED);
+
+  private static final ResourceFactory<InputStream> INSTANCE = CachedResourceFactory
+      .create(new GcpObjectStorageFactory());
+
+  private GcpObjectStorageFactory() {
+  }
+
+  /**
+   * Returns a singleton of {@code GcpVaultSecretFactory}.
+   * 
+   * @return a singleton of {@code GcpVaultSecretFactory}
+   */
+  public static ResourceFactory<InputStream> getInstance() {
+    return INSTANCE;
+  }
+
+  public Resource<InputStream> request(ParameterSet parameterSet)
+      throws IllegalStateException, IllegalArgumentException {
+    String projectName = parameterSet.getRequired(PROJECT);
+    String bucketName = parameterSet.getRequired(BUCKET);
+    String objectName = parameterSet.getRequired(OBJECT);
+
+    Storage storage = (Storage) StorageOptions.newBuilder().setProjectId(projectName).build().getService();
+    byte[] data = storage.readAllBytes(bucketName, objectName);
+    InputStream stream = new ByteArrayInputStream(data);
+    return Resource.createPermanentResource(stream, false);
+  }
+}

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpVaultSecretPasswordProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpVaultSecretPasswordProvider.java
@@ -1,0 +1,66 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.jdbc.provider.gcp.resource;
+
+import java.util.Base64;
+import java.util.Map;
+
+import oracle.jdbc.spi.PasswordProvider;
+
+/**
+ * <p>
+ * A provider of passwords from the GCP Secret Manager service.
+ * </p>
+ * <p>
+ * This class implements the {@link PasswordProvider} SPI defined by
+ * Oracle JDBC. It is designed to be located and instantiated by
+ * {@link java.util.ServiceLoader}.
+ * </p>
+ */
+public class GcpVaultSecretPasswordProvider extends GcpVaultSecretProvider implements PasswordProvider {
+
+  public GcpVaultSecretPasswordProvider() {
+    super("secret-password");
+  }
+
+  @Override
+  public char[] getPassword(Map<Parameter, CharSequence> parameterValues) {
+    return Base64.getEncoder().encodeToString(getSecret(parameterValues).toByteArray()).toCharArray();
+  }
+
+}

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpVaultSecretPasswordProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpVaultSecretPasswordProvider.java
@@ -37,9 +37,7 @@
  */
 package oracle.jdbc.provider.gcp.resource;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
-import java.util.Base64;
 import java.util.Map;
 
 import com.google.protobuf.ByteString;

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpVaultSecretProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpVaultSecretProvider.java
@@ -1,0 +1,87 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.jdbc.provider.gcp.resource;
+
+import java.util.Map;
+
+import com.google.protobuf.ByteString;
+
+import oracle.jdbc.provider.gcp.secrets.GcpVaultSecretFactory;
+import oracle.jdbc.provider.parameter.ParameterSet;
+import oracle.jdbc.provider.resource.AbstractResourceProvider;
+import oracle.jdbc.provider.resource.ResourceParameter;
+
+/**
+ * Internal class to be inherited by other resource providers using secrets.
+ */
+class GcpVaultSecretProvider extends AbstractResourceProvider {
+
+  private static final ResourceParameter[] PARAMETERS = {
+      new ResourceParameter("secretVersionName", GcpVaultSecretFactory.SECRET_VERSION_NAME)
+  };
+
+  protected GcpVaultSecretProvider(String valueType) {
+    super("gcp", valueType, PARAMETERS);
+  }
+
+  /**
+   * <p>
+   * Returns a secret identified by a parameter named "secretVersionName" which
+   * configures {@link GcpVaultSecretFactory#SECRET_VERSION_NAME}. This method
+   * parses these parameters from text values.
+   * </p>
+   * <p>
+   * This method is designed to be called from subclasses which implement an
+   * {@link oracle.jdbc.spi.OracleResourceProvider} SPI.
+   * </p>
+   *
+   * @param parameterValues Text values of parameters. Not null.
+   * @return The identified secret. Not null.
+   */
+  protected final ByteString getSecret(
+      Map<Parameter, CharSequence> parameterValues) {
+
+    ParameterSet parameterSet = parseParameterValues(parameterValues);
+
+    return GcpVaultSecretFactory.getInstance()
+        .request(parameterSet)
+        .getContent()
+        .getData();
+  }
+
+}

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpVaultSecretUsernameProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpVaultSecretUsernameProvider.java
@@ -1,0 +1,66 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.jdbc.provider.gcp.resource;
+
+import java.nio.charset.Charset;
+import java.util.Map;
+
+import oracle.jdbc.spi.UsernameProvider;
+
+/**
+ * <p>
+ * A provider of usernames from the GCP Secret Manager service.
+ * </p>
+ * <p>
+ * This class implements the {@link UsernameProvider} SPI defined by
+ * Oracle JDBC. It is designed to be located and instantiated by
+ * {@link java.util.ServiceLoader}.
+ * </p>
+ */
+public class GcpVaultSecretUsernameProvider extends GcpVaultSecretProvider implements UsernameProvider {
+
+  public GcpVaultSecretUsernameProvider() {
+    super("secret-username");
+  }
+
+  @Override
+  public String getUsername(Map<Parameter, CharSequence> parameterValues) {
+    return getSecret(parameterValues).toString(Charset.defaultCharset());
+  }
+
+}

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/secrets/GcpVaultSecretFactory.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/secrets/GcpVaultSecretFactory.java
@@ -1,0 +1,116 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.jdbc.provider.gcp.secrets;
+
+import static oracle.jdbc.provider.parameter.Parameter.CommonAttribute.REQUIRED;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretName;
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
+
+import oracle.jdbc.provider.cache.CachedResourceFactory;
+import oracle.jdbc.provider.factory.Resource;
+import oracle.jdbc.provider.factory.ResourceFactory;
+import oracle.jdbc.provider.parameter.Parameter;
+import oracle.jdbc.provider.parameter.ParameterSet;
+
+/**
+ * <p>
+ * Factory for requesting secrets from the Vault service. Secrets are
+ * represented as {@link SecretPayload} objects. Oracle JDBC can use the content
+ * of a secret as a database password, or any other security sensitive value.
+ * </p>
+ */
+public class GcpVaultSecretFactory implements ResourceFactory<SecretPayload> {
+
+  /** The secret version name for the secret */
+  public static final Parameter<String> SECRET_VERSION_NAME = Parameter.create(REQUIRED);
+
+  private static final ResourceFactory<SecretPayload> INSTANCE = CachedResourceFactory
+      .create(new GcpVaultSecretFactory());
+
+  private GcpVaultSecretFactory() {
+  }
+
+  /**
+   * Returns a singleton of {@code GcpVaultSecretFactory}.
+   * 
+   * @return a singleton of {@code GcpVaultSecretFactory}
+   */
+  public static ResourceFactory<SecretPayload> getInstance() {
+    return INSTANCE;
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Requests the content of a secret bundle from the Vault service. The
+   * {@code parameterSet} is required to include a {@link #SECRET_VERSION_NAME}.
+   * </p>
+   */
+  @Override
+  public Resource<SecretPayload> request(ParameterSet parameterSet)
+      throws IllegalStateException, IllegalArgumentException {
+    String paramerter = parameterSet.getRequired(SECRET_VERSION_NAME);
+
+    try (SecretManagerServiceClient client = SecretManagerServiceClient.create()) {
+      SecretVersionName secretVersionName = SecretVersionName.parse(paramerter);
+      SecretName secretName = SecretName.of(secretVersionName.getProject(), secretVersionName.getSecret());
+      Secret secret = client.getSecret(secretName);
+      AccessSecretVersionResponse response = client.accessSecretVersion(secretVersionName);
+      if (secret.hasExpireTime()) {
+        OffsetDateTime expireTime = OffsetDateTime
+            .ofInstant(Instant.ofEpochMilli(secret.getExpireTime().getNanos() * 1000), ZoneId.systemDefault());
+        return Resource.createExpiringResource(response.getPayload(), expireTime, true);
+      } else {
+        return Resource.createPermanentResource(response.getPayload(), true);
+      }
+    } catch (IOException io) {
+      throw new IllegalStateException(io);
+    }
+  }
+
+}

--- a/ojdbc-provider-gcp/src/main/resources/META-INF/services/oracle.jdbc.spi.OracleConfigurationJsonSecretProvider
+++ b/ojdbc-provider-gcp/src/main/resources/META-INF/services/oracle.jdbc.spi.OracleConfigurationJsonSecretProvider
@@ -1,0 +1,1 @@
+oracle.jdbc.provider.gcp.configuration.GcpJsonVaultSecretProvider

--- a/ojdbc-provider-gcp/src/main/resources/META-INF/services/oracle.jdbc.spi.OracleConfigurationProvider
+++ b/ojdbc-provider-gcp/src/main/resources/META-INF/services/oracle.jdbc.spi.OracleConfigurationProvider
@@ -1,0 +1,2 @@
+oracle.jdbc.provider.gcp.configuration.GcpObjectStorageConfigurationProvider
+oracle.jdbc.provider.gcp.configuration.GcpVaultSecretConfigurationProvider

--- a/ojdbc-provider-gcp/src/main/resources/META-INF/services/oracle.jdbc.spi.PasswordProvider
+++ b/ojdbc-provider-gcp/src/main/resources/META-INF/services/oracle.jdbc.spi.PasswordProvider
@@ -1,0 +1,1 @@
+oracle.jdbc.provider.gcp.resource.GcpVaultSecretPasswordProvider

--- a/ojdbc-provider-gcp/src/main/resources/META-INF/services/oracle.jdbc.spi.UsernameProvider
+++ b/ojdbc-provider-gcp/src/main/resources/META-INF/services/oracle.jdbc.spi.UsernameProvider
@@ -1,0 +1,1 @@
+oracle.jdbc.provider.gcp.resource.GcpVaultSecretUsernameProvider

--- a/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/configuration/GcpObjectStorageProviderTest.java
+++ b/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/configuration/GcpObjectStorageProviderTest.java
@@ -1,0 +1,72 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.provider.gcp.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import oracle.jdbc.provider.TestProperties;
+import oracle.jdbc.spi.OracleConfigurationProvider;
+
+public class GcpObjectStorageProviderTest {
+
+  private enum GcpTestProperties {
+    GCP_OBJECT_STORAGE_URL
+  }
+
+  static {
+    OracleConfigurationProvider.allowedProviders.add("gcpobject");
+  }
+
+  private static final OracleConfigurationProvider PROVIDER = OracleConfigurationProvider.find("gcpobject");
+
+  @Test
+  public void testDefaultAuthentication() throws SQLException {
+    String location = TestProperties.getOrAbort(GcpTestProperties.GCP_OBJECT_STORAGE_URL);
+    Properties properties = PROVIDER
+        .getConnectionProperties(location);
+    assertTrue(properties.containsKey("URL"), "Contains property URL");
+    assertTrue(properties.containsKey("user"), "Contains property user");
+    assertTrue(properties.containsKey("password"), "Contains property password");
+  }
+
+}

--- a/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/configuration/GcpObjectStorageProviderTest.java
+++ b/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/configuration/GcpObjectStorageProviderTest.java
@@ -56,10 +56,10 @@ public class GcpObjectStorageProviderTest {
   }
 
   static {
-    OracleConfigurationProvider.allowedProviders.add("gcpobject");
+    OracleConfigurationProvider.allowedProviders.add("gcpstorage");
   }
 
-  private static final OracleConfigurationProvider PROVIDER = OracleConfigurationProvider.find("gcpobject");
+  private static final OracleConfigurationProvider PROVIDER = OracleConfigurationProvider.find("gcpstorage");
 
   @Test
   public void testDefaultAuthentication() throws SQLException {

--- a/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/configuration/GcpObjectStorageProviderTest.java
+++ b/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/configuration/GcpObjectStorageProviderTest.java
@@ -42,11 +42,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.sql.SQLException;
 import java.util.Properties;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import oracle.jdbc.provider.TestProperties;
 import oracle.jdbc.spi.OracleConfigurationProvider;
 
+@Disabled
 public class GcpObjectStorageProviderTest {
 
   private enum GcpTestProperties {

--- a/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/configuration/GcpVaultSecretConfigurationProviderTest.java
+++ b/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/configuration/GcpVaultSecretConfigurationProviderTest.java
@@ -42,11 +42,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.sql.SQLException;
 import java.util.Properties;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import oracle.jdbc.provider.TestProperties;
 import oracle.jdbc.spi.OracleConfigurationProvider;
 
+@Disabled
 public class GcpVaultSecretConfigurationProviderTest {
   private enum GcpTestProperties {
     SECRET_VERSION_NAME_CONFIG

--- a/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/configuration/GcpVaultSecretConfigurationProviderTest.java
+++ b/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/configuration/GcpVaultSecretConfigurationProviderTest.java
@@ -1,0 +1,70 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.provider.gcp.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import oracle.jdbc.provider.TestProperties;
+import oracle.jdbc.spi.OracleConfigurationProvider;
+
+public class GcpVaultSecretConfigurationProviderTest {
+  private enum GcpTestProperties {
+    SECRET_VERSION_NAME_CONFIG
+  }
+
+  static {
+    OracleConfigurationProvider.allowedProviders.add("gcpsecret");
+  }
+
+  private static final OracleConfigurationProvider PROVIDER = OracleConfigurationProvider.find("gcpsecret");
+
+  @Test
+  public void testGetProperties() throws SQLException {
+    String secretVersionName = TestProperties.getOrAbort(GcpTestProperties.SECRET_VERSION_NAME_CONFIG);
+    Properties properties = PROVIDER
+        .getConnectionProperties(secretVersionName);
+    assertTrue(properties.containsKey("URL"), "Contains property URL");
+    assertTrue(properties.containsKey("user"), "Contains property user");
+    assertTrue(properties.containsKey("password"), "Contains property password");
+  }
+}

--- a/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/resource/GcpVaultSecretPasswordProviderTest.java
+++ b/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/resource/GcpVaultSecretPasswordProviderTest.java
@@ -46,6 +46,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import oracle.jdbc.provider.TestProperties;
@@ -54,6 +55,7 @@ import oracle.jdbc.spi.PasswordProvider;
 import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.createParameterValues;
 import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.findProvider;
 
+@Disabled
 public class GcpVaultSecretPasswordProviderTest {
   private static final PasswordProvider PROVIDER = findProvider(
       PasswordProvider.class, "ojdbc-provider-gcp-secret-password");

--- a/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/resource/GcpVaultSecretPasswordProviderTest.java
+++ b/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/resource/GcpVaultSecretPasswordProviderTest.java
@@ -1,0 +1,100 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.provider.gcp.resource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oracle.jdbc.provider.TestProperties;
+import oracle.jdbc.spi.OracleResourceProvider.Parameter;
+import oracle.jdbc.spi.PasswordProvider;
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.createParameterValues;
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.findProvider;
+
+public class GcpVaultSecretPasswordProviderTest {
+  private static final PasswordProvider PROVIDER = findProvider(
+      PasswordProvider.class, "ojdbc-provider-gcp-secret-password");
+
+  private enum GcpTestProperties {
+    SECRET_VERSION_NAME
+  }
+
+  /**
+   * Verifies that {@link PasswordProvider#getParameters()} includes parameters
+   * to configure a vault URL and secret name.
+   */
+  @Test
+  public void testGetParameters() {
+    Collection<? extends Parameter> parameters = PROVIDER.getParameters();
+    assertNotNull(parameters);
+
+    Parameter secretVersionNameParameter = parameters.stream()
+        .filter(parameter -> "secretVersionName".equals(parameter.name()))
+        .findFirst()
+        .orElseThrow(AssertionError::new);
+    assertFalse(secretVersionNameParameter.isSensitive());
+    assertTrue(secretVersionNameParameter.isRequired());
+    assertNull(secretVersionNameParameter.defaultValue());
+
+  }
+
+  /**
+   * Verifies that {@link oracle.jdbc.spi.PasswordProvider#getPassword(Map)}
+   * returns the username identified by a vault URL and secret name.
+   */
+  @Test
+  public void testGetPassword() {
+
+    Map<String, String> testParameters = new HashMap<>();
+    testParameters.put(
+        "secretVersionName", TestProperties.getOrAbort(GcpTestProperties.SECRET_VERSION_NAME));
+
+    Map<Parameter, CharSequence> parameterValues = createParameterValues(PROVIDER,
+        testParameters);
+
+    assertNotNull(PROVIDER.getPassword(parameterValues));
+  }
+}

--- a/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/resource/GcpVaultSecretUsernameProviderTest.java
+++ b/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/resource/GcpVaultSecretUsernameProviderTest.java
@@ -48,12 +48,14 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import oracle.jdbc.provider.TestProperties;
 import oracle.jdbc.spi.OracleResourceProvider.Parameter;
 import oracle.jdbc.spi.UsernameProvider;
 
+@Disabled
 public class GcpVaultSecretUsernameProviderTest {
   private static final UsernameProvider PROVIDER = findProvider(
       UsernameProvider.class, "ojdbc-provider-gcp-secret-username");

--- a/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/resource/GcpVaultSecretUsernameProviderTest.java
+++ b/ojdbc-provider-gcp/src/test/java/oracle/provider/gcp/resource/GcpVaultSecretUsernameProviderTest.java
@@ -1,0 +1,101 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.provider.gcp.resource;
+
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.createParameterValues;
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.findProvider;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oracle.jdbc.provider.TestProperties;
+import oracle.jdbc.spi.OracleResourceProvider.Parameter;
+import oracle.jdbc.spi.UsernameProvider;
+
+public class GcpVaultSecretUsernameProviderTest {
+  private static final UsernameProvider PROVIDER = findProvider(
+      UsernameProvider.class, "ojdbc-provider-gcp-secret-username");
+
+  private enum GcpTestProperties {
+    SECRET_VERSION_NAME
+  }
+
+  /**
+   * Verifies that {@link UsernameProvider#getParameters()} includes parameters
+   * to configure a vault URL and secret name.
+   */
+  @Test
+  public void testGetParameters() {
+    Collection<? extends Parameter> parameters = PROVIDER.getParameters();
+    assertNotNull(parameters);
+
+    Parameter secretVersionNameParameter = parameters.stream()
+        .filter(parameter -> "secretVersionName".equals(parameter.name()))
+        .findFirst()
+        .orElseThrow(AssertionError::new);
+    assertFalse(secretVersionNameParameter.isSensitive());
+    assertTrue(secretVersionNameParameter.isRequired());
+    assertNull(secretVersionNameParameter.defaultValue());
+
+  }
+
+  /**
+   * Verifies that {@link oracle.jdbc.spi.PasswordProvider#getPassword(Map)}
+   * returns the username identified by a vault URL and secret name.
+   */
+  @Test
+  public void testGetUsername() {
+
+    Map<String, String> testParameters = new HashMap<>();
+    testParameters.put(
+        "secretVersionName", TestProperties.getOrAbort(GcpTestProperties.SECRET_VERSION_NAME));
+
+    Map<Parameter, CharSequence> parameterValues = createParameterValues(PROVIDER,
+        testParameters);
+
+    String username = PROVIDER.getUsername(parameterValues);
+    assertNotNull(username);
+  }
+}

--- a/ojdbc-provider-samples/example-configuration.properties
+++ b/ojdbc-provider-samples/example-configuration.properties
@@ -111,4 +111,4 @@ azure_redirect_url=http://localhost:7071
 # Google Cloud Platform
 gcp_secret_version_name=projects/138028249883/secrets/test-secret/versions/2
 gcp_secret_version_name_config=projects/138028249883/secrets/config-secret/versions/4
-gcp_object_storage_properties=project=onyx-eye-426013-i5;bucket=fm-test-bucket-123564;object=testObjectStorage.json
+gcp_cloud_storage_properties=project=onyx-eye-426013-i5;bucket=fm-test-bucket-123564;object=testObjectStorage.json

--- a/ojdbc-provider-samples/example-configuration.properties
+++ b/ojdbc-provider-samples/example-configuration.properties
@@ -107,3 +107,8 @@ client_certificate_password=$3cr3t
 # Set to redirect URL for an interactive authentication which use your account in
 # Azure Active Directory to directly authenticate.
 azure_redirect_url=http://localhost:7071
+
+# Google Cloud Platform
+gcp_secret_version_name=projects/138028249883/secrets/test-secret/versions/2
+gcp_secret_version_name_config=projects/138028249883/secrets/config-secret/versions/4
+gcp_object_storage_properties=project=onyx-eye-426013-i5;bucket=fm-test-bucket-123564;object=testObjectStorage.json

--- a/ojdbc-provider-samples/pom.xml
+++ b/ojdbc-provider-samples/pom.xml
@@ -5,7 +5,7 @@
   <name>Oracle JDBC Provider Code Samples</name>
 
   <artifactId>ojdbc-provider-samples</artifactId>
-  <version>1.0.1</version>
+  <version>${project.parent.version}</version>
   <packaging>jar</packaging>
 
   <parent>
@@ -18,12 +18,17 @@
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc-provider-azure</artifactId>
-      <version>1.0.1</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc-provider-oci</artifactId>
-      <version>1.0.1</version>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc-provider-gcp</artifactId>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.database.security</groupId>

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/configuration/CloudStorageExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/configuration/CloudStorageExample.java
@@ -38,6 +38,7 @@
 package oracle.jdbc.provider.gcp.configuration;
 
 import oracle.jdbc.datasource.impl.OracleDataSource;
+import oracle.jdbc.provider.Configuration;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -46,14 +47,21 @@ import java.sql.Statement;
 
 /**
  * A standalone example that configures Oracle JDBC to be provided with the
- * connection properties retrieved from OCI Object Storage.
+ * connection properties retrieved from GCP Cloud Storage.
  */
-public class SimpleObjectStorageExample {
+public class CloudStorageExample {
+  /**
+   * An GCP Cloud Storage properties configured as a JVM system property,
+   * environment variable, or configuration.properties file entry named
+   * "gcp_cloud_storage_properties".
+   */
+  private static final String OBJECT_PROPERTIES = Configuration
+      .getRequired("gcp_cloud_storage_properties");
 
   /**
    * <p>
    * Connects to a database using connection properties retrieved from GCP
-   * Object Storage.
+   * Cloud Storage.
    * </p>
    * <p>
    * Providers use Google Cloud APIs which support Application Default
@@ -69,7 +77,7 @@ public class SimpleObjectStorageExample {
    * @throws SQLException if an error occurs during the database calls
    */
   public static void main(String[] args) throws SQLException {
-    String url = "jdbc:oracle:thin:@config-gcpstorage://project=onyx-eye-426013-i5;bucket=fm-test-bucket-123564;object=testObjectStorage.json";
+    String url = "jdbc:oracle:thin:@config-gcpstorage://" + OBJECT_PROPERTIES;
 
     // Standard JDBC code
     OracleDataSource ds = new OracleDataSource();

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/configuration/ObjectStorageExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/configuration/ObjectStorageExample.java
@@ -68,7 +68,7 @@ public class ObjectStorageExample {
    * @throws SQLException if an error occurs during the database calls
    */
   public static void main(String[] args) throws SQLException {
-    String url = "jdbc:oracle:thin:@config-gcpobject://" + OBJECT_PROPERTIES;
+    String url = "jdbc:oracle:thin:@config-gcpstorage://" + OBJECT_PROPERTIES;
 
     // Standard JDBC code
     OracleDataSource ds = new OracleDataSource();

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/configuration/SimpleObjectStorageExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/configuration/SimpleObjectStorageExample.java
@@ -37,55 +37,46 @@
  */
 package oracle.jdbc.provider.gcp.configuration;
 
+import oracle.jdbc.datasource.impl.OracleDataSource;
+
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import oracle.jdbc.datasource.impl.OracleDataSource;
-
 /**
  * A standalone example that configures Oracle JDBC to be provided with the
- * connection properties retrieved from GCP Secret Manager.
+ * connection properties retrieved from OCI Object Storage.
  */
-public class SimpleVaultJsonExample {
+public class SimpleObjectStorageExample {
 
   /**
    * <p>
-   * Simple example to retrieve connection properties from GCP Secret Manager.
+   * Connects to a database using connection properties retrieved from GCP
+   * Object Storage.
    * </p>
-   * <p>
-   * To run this example, the payload needs to be stored in GCP Secret Manager.
-   * The payload examples can be found in
-   * {@link oracle.jdbc.spi.OracleConfigurationProvider}.
-   * </p>
-   * Users need to indicate the resource name of the Secret with the following
-   * syntax:
-   * 
-   * <pre>
-   * jdbc:oracle:thin:@config-gcpvault:{resource-name}
-   * </pre>
    * 
    * @param args the command line arguments
    * @throws SQLException if an error occurs during the database calls
-   **/
+   */
   public static void main(String[] args) throws SQLException {
-    String url = "jdbc:oracle:thin:@config-gcpsecret://projects/138028249883/secrets/config-secret/versions/4";
-    // Sample default URL if non present
-    if (args.length > 0) {
-      url = args[0];
-    }
+    String url = "jdbc:oracle:thin:@config-gcpstorage://project=onyx-eye-426013-i5;bucket=fm-test-bucket-123564;object=testObjectStorage.json";
 
-    // No changes required, configuration provider is loaded at runtime
+    // Standard JDBC code
     OracleDataSource ds = new OracleDataSource();
     ds.setURL(url);
 
-    // Standard JDBC code
+    System.out.println("Connection URL: " + url);
+
     try (Connection cn = ds.getConnection()) {
+      String connectionString = cn.getMetaData().getURL();
+      System.out.println("Connected to: " + connectionString);
+
       Statement st = cn.createStatement();
       ResultSet rs = st.executeQuery("SELECT 'Hello, db' FROM sys.dual");
       if (rs.next())
         System.out.println(rs.getString(1));
     }
   }
+
 }

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/configuration/SimpleVaultJsonExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/configuration/SimpleVaultJsonExample.java
@@ -65,6 +65,15 @@ public class SimpleVaultJsonExample {
    * <pre>
    * jdbc:oracle:thin:@config-gcpvault:{resource-name}
    * </pre>
+   * <p>
+   * Providers use Google Cloud APIs which support Application Default
+   * Credentials; the libraries look for credentials in a set of defined
+   * locations and use those credentials to authenticate requests to the API.
+   * </p>
+   * 
+   * @see <a href=
+   *      "https://cloud.google.com/docs/authentication/application-default-credentials">
+   *      Application Default Credentials</a>
    * 
    * @param args the command line arguments
    * @throws SQLException if an error occurs during the database calls

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/configuration/SimpleVaultJsonExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/configuration/SimpleVaultJsonExample.java
@@ -35,38 +35,66 @@
  ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  ** SOFTWARE.
  */
-package oracle.jdbc.provider.gcp.resource;
+package oracle.jdbc.provider.gcp.configuration;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
-import java.util.Base64;
-import java.util.Map;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 
-import com.google.protobuf.ByteString;
-
-import oracle.jdbc.spi.PasswordProvider;
+import oracle.jdbc.datasource.impl.OracleDataSource;
+import oracle.jdbc.provider.Configuration;
 
 /**
- * <p>
- * A provider of passwords from the GCP Secret Manager service.
- * </p>
- * <p>
- * This class implements the {@link PasswordProvider} SPI defined by
- * Oracle JDBC. It is designed to be located and instantiated by
- * {@link java.util.ServiceLoader}.
- * </p>
+ * A standalone example that configures Oracle JDBC to be provided with the
+ * connection properties retrieved from GCP Secret Manager.
  */
-public class GcpVaultSecretPasswordProvider extends GcpVaultSecretProvider implements PasswordProvider {
+public class SimpleVaultJsonExample {
 
-  public GcpVaultSecretPasswordProvider() {
-    super("secret-password");
+  /**
+   * An GCP SecretManager resource name configured as a JVM system property,
+   * environment variable, or configuration.properties file entry named
+   * "gcp_secret_version_name_config".
+   */
+  private static final String RESOURCE_NAME = Configuration
+      .getRequired("gcp_secret_version_name_config");
+
+  /**
+   * <p>
+   * Simple example to retrieve connection properties from GCP Secret Manager.
+   * </p>
+   * <p>
+   * To run this example, the payload needs to be stored in GCP Secret Manager.
+   * The payload examples can be found in
+   * {@link oracle.jdbc.spi.OracleConfigurationProvider}.
+   * </p>
+   * Users need to indicate the resource name of the Secret with the following
+   * syntax:
+   * 
+   * <pre>
+   * jdbc:oracle:thin:@config-gcpvault:{resource-name}
+   * </pre>
+   * 
+   * @param args the command line arguments
+   * @throws SQLException if an error occurs during the database calls
+   **/
+  public static void main(String[] args) throws SQLException {
+    String url = "jdbc:oracle:thin:@config-gcpsecret://" + RESOURCE_NAME;
+    // Sample default URL if non present
+    if (args.length > 0) {
+      url = args[0];
+    }
+
+    // No changes required, configuration provider is loaded at runtime
+    OracleDataSource ds = new OracleDataSource();
+    ds.setURL(url);
+
+    // Standard JDBC code
+    try (Connection cn = ds.getConnection()) {
+      Statement st = cn.createStatement();
+      ResultSet rs = st.executeQuery("SELECT 'Hello, db' FROM sys.dual");
+      if (rs.next())
+        System.out.println(rs.getString(1));
+    }
   }
-
-  @Override
-  public char[] getPassword(Map<Parameter, CharSequence> parameterValues) {
-    ByteString secret = getSecret(parameterValues);
-    String password = secret.toString(Charset.defaultCharset());
-    return password.toCharArray();
-  }
-
 }

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/configuration/VaultJsonExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/configuration/VaultJsonExample.java
@@ -75,6 +75,16 @@ public class VaultJsonExample {
    * jdbc:oracle:thin:@config-gcpvault:{resource-name}
    * </pre>
    * 
+   * <p>
+   * Providers use Google Cloud APIs which support Application Default
+   * Credentials; the libraries look for credentials in a set of defined
+   * locations and use those credentials to authenticate requests to the API.
+   * </p>
+   * 
+   * @see <a href=
+   *      "https://cloud.google.com/docs/authentication/application-default-credentials">
+   *      Application Default Credentials</a>
+   * 
    * @param args the command line arguments
    * @throws SQLException if an error occurs during the database calls
    **/

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/configuration/VaultJsonExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/configuration/VaultJsonExample.java
@@ -43,12 +43,21 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import oracle.jdbc.datasource.impl.OracleDataSource;
+import oracle.jdbc.provider.Configuration;
 
 /**
  * A standalone example that configures Oracle JDBC to be provided with the
  * connection properties retrieved from GCP Secret Manager.
  */
-public class SimpleVaultJsonExample {
+public class VaultJsonExample {
+
+  /**
+   * An GCP SecretManager resource name configured as a JVM system property,
+   * environment variable, or configuration.properties file entry named
+   * "gcp_secret_version_name_config".
+   */
+  private static final String RESOURCE_NAME = Configuration
+      .getRequired("gcp_secret_version_name_config");
 
   /**
    * <p>
@@ -70,7 +79,7 @@ public class SimpleVaultJsonExample {
    * @throws SQLException if an error occurs during the database calls
    **/
   public static void main(String[] args) throws SQLException {
-    String url = "jdbc:oracle:thin:@config-gcpsecret://projects/138028249883/secrets/config-secret/versions/4";
+    String url = "jdbc:oracle:thin:@config-gcpsecret://" + RESOURCE_NAME;
     // Sample default URL if non present
     if (args.length > 0) {
       url = args[0];

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/resource/SimpleVaultSecretPasswordResourceExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/resource/SimpleVaultSecretPasswordResourceExample.java
@@ -35,46 +35,54 @@
  ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  ** SOFTWARE.
  */
-package oracle.jdbc.provider.gcp.configuration;
+package oracle.jdbc.provider.gcp.resource;
 
 import oracle.jdbc.datasource.impl.OracleDataSource;
-import oracle.jdbc.provider.Configuration;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Properties;
 
 /**
  * A standalone example that configures Oracle JDBC to be provided with the
  * connection properties retrieved from OCI Object Storage.
  */
-public class ObjectStorageExample {
-  /**
-   * An GCP Object Storage properties configured as a JVM system property,
-   * environment variable, or configuration.properties file entry named
-   * "gcp_object_storage_properties".
-   */
-  private static final String OBJECT_PROPERTIES = Configuration
-      .getRequired("gcp_object_storage_properties");
+public class SimpleVaultSecretPasswordResourceExample {
+
+  private static final String DB_URL = "(description=(retry_count=2)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-phoenix-1.oraclecloud.com))(connect_data=(service_name=gebqqvpozhjbqbs_awyonurbg0gp0smq_tp.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))";
+  private static final String RESOURCE_NAME = "projects/138028249883/secrets/test-secret/versions/2";
 
   /**
    * <p>
    * Connects to a database using connection properties retrieved from GCP
    * Object Storage.
    * </p>
+   * <p>
+   * Providers use Google Cloud APIs which support Application Default
+   * Credentials; the libraries look for credentials in a set of defined
+   * locations and use those credentials to authenticate requests to the API.
+   * </p>
+   * 
+   * @see <a href=
+   *      "https://cloud.google.com/docs/authentication/application-default-credentials">
+   *      Application Default Credentials</a>
    * 
    * @param args the command line arguments
    * @throws SQLException if an error occurs during the database calls
    */
   public static void main(String[] args) throws SQLException {
-    String url = "jdbc:oracle:thin:@config-gcpstorage://" + OBJECT_PROPERTIES;
+    String url = "jdbc:oracle:thin:@" + DB_URL;
 
     // Standard JDBC code
     OracleDataSource ds = new OracleDataSource();
     ds.setURL(url);
-
-    System.out.println("Connection URL: " + url);
+    ds.setUser("DB_USER");
+    Properties properties = new Properties();
+    properties.put("oracle.jdbc.provider.password", "ojdbc-provider-gcp-secret-password");
+    properties.put("oracle.jdbc.provider.password.secretVersionName", RESOURCE_NAME);
+    ds.setConnectionProperties(properties);
 
     try (Connection cn = ds.getConnection()) {
       String connectionString = cn.getMetaData().getURL();

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/resource/VaultSecretPasswordResourceExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/resource/VaultSecretPasswordResourceExample.java
@@ -1,0 +1,96 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.jdbc.provider.gcp.resource;
+
+import oracle.jdbc.datasource.impl.OracleDataSource;
+import oracle.jdbc.provider.Configuration;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * A standalone example that configures Oracle JDBC to be provided with the
+ * connection properties retrieved from OCI Object Storage.
+ */
+public class VaultSecretPasswordResourceExample {
+  /**
+   * An GCP SecretManager resource name configured as a JVM system property,
+   * environment variable, or configuration.properties file entry named
+   * "gcp_secret_version_name".
+   */
+  private static final String RESOURCE_NAME = Configuration
+      .getRequired("gcp_secret_version_name");
+
+  private static final String DB_URL = "(description=(retry_count=2)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-phoenix-1.oraclecloud.com))(connect_data=(service_name=gebqqvpozhjbqbs_awyonurbg0gp0smq_tp.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))";
+
+  /**
+   * <p>
+   * Connects to a database using connection properties retrieved from GCP
+   * Object Storage.
+   * </p>
+   * 
+   * @param args the command line arguments
+   * @throws SQLException if an error occurs during the database calls
+   */
+  public static void main(String[] args) throws SQLException {
+    String url = "jdbc:oracle:thin:@" + DB_URL;
+
+    // Standard JDBC code
+    OracleDataSource ds = new OracleDataSource();
+    ds.setURL(url);
+    ds.setUser("DB_USER");
+    Properties properties = new Properties();
+    properties.put("oracle.jdbc.provider.password", "ojdbc-provider-gcp-secret-password");
+    properties.put("oracle.jdbc.provider.password.secretVersionName", RESOURCE_NAME);
+    ds.setConnectionProperties(properties);
+
+    try (Connection cn = ds.getConnection()) {
+      String connectionString = cn.getMetaData().getURL();
+      System.out.println("Connected to: " + connectionString);
+
+      Statement st = cn.createStatement();
+      ResultSet rs = st.executeQuery("SELECT 'Hello, db' FROM sys.dual");
+      if (rs.next())
+        System.out.println(rs.getString(1));
+    }
+  }
+
+}

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/resource/VaultSecretPasswordResourceExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/resource/VaultSecretPasswordResourceExample.java
@@ -66,6 +66,15 @@ public class VaultSecretPasswordResourceExample {
    * Connects to a database using connection properties retrieved from GCP
    * Object Storage.
    * </p>
+   * <p>
+   * Providers use Google Cloud APIs which support Application Default
+   * Credentials; the libraries look for credentials in a set of defined
+   * locations and use those credentials to authenticate requests to the API.
+   * </p>
+   * 
+   * @see <a href=
+   *      "https://cloud.google.com/docs/authentication/application-default-credentials">
+   *      Application Default Credentials</a>
    * 
    * @param args the command line arguments
    * @throws SQLException if an error occurs during the database calls

--- a/pom.xml
+++ b/pom.xml
@@ -61,10 +61,16 @@
     <module>ojdbc-provider-oci</module>
     <module>ojdbc-provider-samples</module>
     <module>ojdbc-provider-opentelemetry</module>
+    <module>ojdbc-provider-gcp</module>
   </modules>
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>com.oracle.database.jdbc</groupId>
+        <artifactId>ojdbc-provider-common</artifactId>
+        <version>1.0.1</version>
+      </dependency>
       <dependency>
         <groupId>com.oracle.database.jdbc</groupId>
         <artifactId>ojdbc8</artifactId>


### PR DESCRIPTION
This project add the following providers for Google Cloud Platform:

- Configuration:
  - GcpJsonVaultSecretProvider: which gets the JSON configuration from a GPC Secret Manager secret
  - GcpObjectStorageConfigurationProvider: which gets the JSON configuration from a GPC Cloud Storage object
- Resource:
  -  GcpVaultSecretPasswordProvider: which gets the password from a GPC Secret Manager secret
  - GcpVaultSecretUsernameProvider: which gets the username from a GPC Secret Manager secret

This pull request also adds samples on how to use these providers.