### PR TITLE
102 azure tcps seps wallet support

### DIFF
--- a/ojdbc-provider-azure/example-key-vault-wallet.properties
+++ b/ojdbc-provider-azure/example-key-vault-wallet.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2024 Oracle and/or its affiliates.
 #
 # The Universal Permissive License (UPL), Version 1.0
 #

--- a/ojdbc-provider-azure/example-key-vault-wallet.properties
+++ b/ojdbc-provider-azure/example-key-vault-wallet.properties
@@ -37,7 +37,7 @@
 ################################################################################
 
 # An example of a connection properties file that configures Oracle JDBC to
-# obtain a TLS wallet from Azure Key Vault.
+# obtain a TLS wallet and SEPS credentials from Azure Key Vault.
 #
 # This file can be located by Oracle JDBC using the "oracle.jdbc.config.file"
 # connection property. For details, see:
@@ -59,4 +59,24 @@ oracle.jdbc.provider.tlsConfiguration.password=${TLS_FILE_PASSWORD}
 # This can be configured as an environment variable or JVM system property named "TLS_FILE_TYPE":
 oracle.jdbc.provider.tlsConfiguration.type=${TLS_FILE_TYPE}
 
+# Configures the Azure Key Vault SEPS (Secure External Password Store) Provider.
+# The vault URL and secret name are configured as environment variables or JVM system properties
+# named "KEY_VAULT_URL" and "SEPS_WALLET_SECRET_NAME" respectively:
+oracle.jdbc.provider.username=ojdbc-provider-azure-key-vault-seps
+oracle.jdbc.provider.password=ojdbc-provider-azure-key-vault-seps
+
+# Configures the vault URL and secret name for SEPS.
+oracle.jdbc.provider.username.vaultUrl=${KEY_VAULT_URL}
+oracle.jdbc.provider.username.secretName=${SEPS_WALLET_SECRET_NAME}
+oracle.jdbc.provider.password.vaultUrl=${KEY_VAULT_URL}
+oracle.jdbc.provider.password.secretName=${SEPS_WALLET_SECRET_NAME}
+
+# Optional password for SEPS Wallet stored in Azure Key Vault
+oracle.jdbc.provider.username.walletPassword=${SEPS_WALLET_PASSWORD}
+oracle.jdbc.provider.password.walletPassword=${SEPS_WALLET_PASSWORD}
+
+# Optional connection string index for SEPS Wallet
+# This determines which set of credentials (username/password) to use from the SEPS Wallet
+oracle.jdbc.provider.username.connectionStringIndex=${SEPS_CONNECTION_STRING_INDEX}
+oracle.jdbc.provider.password.connectionStringIndex=${SEPS_CONNECTION_STRING_INDEX}
 

--- a/ojdbc-provider-azure/example-test.properties
+++ b/ojdbc-provider-azure/example-test.properties
@@ -126,3 +126,20 @@ AZURE_KEY_VAULT_URL=https://example-key-vault-name.vault.azure.net
 # The name of a Key Vault secret
 AZURE_KEY_VAULT_SECRET_NAME=example-name
 
+# The name of a Key Vault secret for TCPS (TLS) wallet
+AZURE_TLS_WALLET_SECRET_NAME=example-tcps-wallet-secret-name
+
+# The type of the file stored in Key Vault (SSO, PKCS12, PEM)
+AZURE_TLS_FILE_TYPE=PKCS12
+
+# Optional password for the TLS file stored in Key Vault
+AZURE_TLS_FILE_PASSWORD=******
+
+# The name of a Key Vault secret for SEPS wallet
+AZURE_SEPS_WALLET_SECRET_NAME=example-seps-wallet-secret-name
+
+# Optional password for the SEPS wallet stored in Key Vault
+AZURE_SEPS_WALLET_PASSWORD=*****
+
+# Optional index to select specific credentials from SEPS wallet
+AZURE_SEPS_CONNECTION_STRING_INDEX=1

--- a/ojdbc-provider-azure/example-vault-wallet.properties
+++ b/ojdbc-provider-azure/example-vault-wallet.properties
@@ -1,0 +1,62 @@
+################################################################################
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or data
+# (collectively the "Software"), free of charge and under any and all copyright
+# rights in the Software, and any and all patent rights owned or freely
+# licensable by each licensor hereunder covering either (i) the unmodified
+# Software as contributed to or provided by such licensor, or (ii) the Larger
+# Works (as defined below), to deal in both
+#
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software (each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition:
+# The above copyright notice and either this complete permission notice or at
+# a minimum a reference to the UPL must be included in all copies or
+# substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+################################################################################
+
+# An example of a connection properties file that configures Oracle JDBC to
+# obtain a TLS wallet from Azure Key Vault.
+#
+# This file can be located by Oracle JDBC using the "oracle.jdbc.config.file"
+# connection property. For details, see:
+# https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE
+
+# Configures the Azure Key Vault TLS (TCPS) File Provider. The vault URL and
+# secret name are configured as environment variables or JVM system properties named
+# "KEY_VAULT_URL" and "TLS_WALLET_SECRET_NAME" respectively:
+oracle.jdbc.provider.tlsConfiguration=ojdbc-provider-azure-key-vault-tls
+oracle.jdbc.provider.tlsConfiguration.vaultUrl=${KEY_VAULT_URL}
+oracle.jdbc.provider.tlsConfiguration.secretName=${TLS_WALLET_SECRET_NAME}
+
+# Configures the Azure Key Vault TLS File Password Provider. The password for the
+# file is optional and can be configured as an environment variable or JVM
+# system property named "TLS_FILE_PASSWORD":
+oracle.jdbc.provider.tlsConfiguration.password=${TLS_FILE_PASSWORD}
+
+# Specifies the file type (SSO, PKCS12, or PEM). This determines how the file is processed.
+# This can be configured as an environment variable or JVM system property named "TLS_FILE_TYPE":
+oracle.jdbc.provider.tlsConfiguration.type=${TLS_FILE_TYPE}
+
+

--- a/ojdbc-provider-azure/pom.xml
+++ b/ojdbc-provider-azure/pom.xml
@@ -29,7 +29,6 @@
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc-provider-common</artifactId>
-      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
@@ -64,11 +63,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.oracle.database.security</groupId>
-      <artifactId>oraclepki</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProvider.java
@@ -1,5 +1,5 @@
 /*
- ** Copyright (c) 2023 Oracle and/or its affiliates.
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
  **
  ** The Universal Permissive License (UPL), Version 1.0
  **

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProvider.java
@@ -82,8 +82,8 @@ public class KeyVaultSEPSProvider
 
   /**
    * Retrieves the OracleWallet by decoding the base64-encoded wallet stored
-   * in OCI Vault and opening it as either SSO or PKCS12, based on whether a
-   * password is provided.
+   * in Azure Key Vault and opening it as either SSO, PKCS12, or PEM, based on
+   * whether a password is provided.
    */
   private WalletUtils.Credentials getWalletCredentials(
           Map<OracleResourceProvider.Parameter, CharSequence> parameterValues) {

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProvider.java
@@ -1,0 +1,106 @@
+/*
+ ** Copyright (c) 2023 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.jdbc.provider.azure.resource;
+
+import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import oracle.jdbc.provider.azure.keyvault.KeyVaultSecretFactory;
+import oracle.jdbc.provider.parameter.ParameterSet;
+import oracle.jdbc.provider.resource.ResourceParameter;
+import oracle.jdbc.provider.util.WalletUtils;
+import oracle.jdbc.spi.OracleResourceProvider;
+import oracle.jdbc.spi.PasswordProvider;
+import oracle.jdbc.spi.UsernameProvider;
+
+import java.util.Base64;
+import java.util.Map;
+
+import static oracle.jdbc.provider.util.CommonParameters.CONNECTION_STRING_INDEX;
+import static oracle.jdbc.provider.util.CommonParameters.PASSWORD;
+
+public class KeyVaultSEPSProvider
+   extends KeyVaultSecretProvider
+   implements UsernameProvider, PasswordProvider {
+
+  private static final ResourceParameter[] SEPS_PARAMETERS = {
+          new ResourceParameter("walletPassword", PASSWORD),
+          new ResourceParameter("connectionStringIndex", CONNECTION_STRING_INDEX)
+  };
+
+  /**
+   * A public no-arg constructor used by {@link java.util.ServiceLoader} to
+   * construct an instance of this provider.
+   */
+  public KeyVaultSEPSProvider() {
+    super("key-vault-seps", SEPS_PARAMETERS);
+  }
+
+  @Override
+  public String getUsername(Map<Parameter, CharSequence> parameterValues) {
+    return getWalletCredentials(parameterValues).username();
+  }
+
+  @Override
+  public char[] getPassword(Map<Parameter, CharSequence> parameterValues) {
+    return getWalletCredentials(parameterValues).password();
+  }
+
+  /**
+   * Retrieves the OracleWallet by decoding the base64-encoded wallet stored
+   * in OCI Vault and opening it as either SSO or PKCS12, based on whether a
+   * password is provided.
+   */
+  private WalletUtils.Credentials getWalletCredentials(
+          Map<OracleResourceProvider.Parameter, CharSequence> parameterValues) {
+
+    ParameterSet parameterSet = parseParameterValues(parameterValues);
+    KeyVaultSecret secret = KeyVaultSecretFactory
+            .getInstance()
+            .request(parameterSet)
+            .getContent();
+
+    char[] walletPassword = parameterSet.getOptional(PASSWORD) != null
+            ? parameterSet.getOptional(PASSWORD).toCharArray()
+            : null;
+
+    String connectionStringIndex = parameterSet.getOptional(CONNECTION_STRING_INDEX);
+    byte[] walletBytes = Base64.getDecoder().decode(secret.getValue());
+    return WalletUtils.getCredentials(walletBytes, walletPassword, connectionStringIndex);
+  }
+
+}

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultSecretProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultSecretProvider.java
@@ -41,6 +41,7 @@ package oracle.jdbc.provider.azure.resource;
 import oracle.jdbc.provider.azure.keyvault.KeyVaultSecretFactory;
 import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.provider.resource.ResourceParameter;
+import oracle.jdbc.provider.util.ResourceParameterUtils;
 
 import java.util.Map;
 
@@ -62,6 +63,11 @@ class KeyVaultSecretProvider extends AzureResourceProvider {
 
   protected KeyVaultSecretProvider(String valueType) {
     super(valueType, PARAMETERS);
+  }
+
+  public KeyVaultSecretProvider(String valueType, ResourceParameter[] additionalParameters) {
+    super(valueType, ResourceParameterUtils
+            .combineParameters(PARAMETERS, additionalParameters));
   }
 
   /**

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProvider.java
@@ -36,36 +36,37 @@
  ** SOFTWARE.
  */
 
-package oracle.jdbc.provider.oci.resource;
+package oracle.jdbc.provider.azure.resource;
 
-import oracle.jdbc.provider.oci.vault.Secret;
-import oracle.jdbc.provider.oci.vault.SecretFactory;
+import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import oracle.jdbc.provider.azure.keyvault.KeyVaultSecretFactory;
 import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.provider.resource.ResourceParameter;
 import oracle.jdbc.provider.util.TlsUtils;
 import oracle.jdbc.spi.TlsConfigurationProvider;
 
+
 import javax.net.ssl.SSLContext;
 import java.util.Base64;
 import java.util.Map;
 
-import static oracle.jdbc.provider.oci.vault.SecretFactory.OCID;
-import static oracle.jdbc.provider.util.CommonParameters.TYPE;
+
 import static oracle.jdbc.provider.util.CommonParameters.PASSWORD;
+import static oracle.jdbc.provider.util.CommonParameters.TYPE;
+
 
 /**
  * <p>
  * A provider for TCPS/TLS files used to establish secure TLS communication
- * with an Autonomous Database. The file is retrieved from OCI Vault, where
- * it is stored as a base64-encoded string. This provider supports different
- * file types including SSO, PKCS12, and PEM formats.
+ * with an Autonomous Database. The file is retrieved from Azure Key Vault,
+ * where it is stored as a base64-encoded string. This provider supports
+ * different file types including SSO, PKCS12, and PEM formats.
  * </p>
  * <p>
  * The type of the file must be explicitly specified using the {@code type}
  * parameter. Based on the type, the file may contain private keys and
  * certificates for establishing secure communication. A password is only
- * required
- * for PKCS12 or encrypted PEM files.
+ * required for PKCS12 or encrypted PEM files.
  * </p>
  * <p>
  * This class implements the {@link TlsConfigurationProvider} SPI defined by
@@ -73,12 +74,11 @@ import static oracle.jdbc.provider.util.CommonParameters.PASSWORD;
  * {@link java.util.ServiceLoader}.
  * </p>
  */
-public class VaultTCPSProvider
-        extends OciResourceProvider
+public class KeyVaultTCPSProvider
+        extends KeyVaultSecretProvider
         implements TlsConfigurationProvider {
 
-  private static final ResourceParameter[] PARAMETERS = {
-          new ResourceParameter("ocid", OCID),
+  private static final ResourceParameter[] TCPS_PARAMETERS = {
           new ResourceParameter("password", PASSWORD),
           new ResourceParameter("type", TYPE)
   };
@@ -87,25 +87,23 @@ public class VaultTCPSProvider
    * A public no-arg constructor used by {@link java.util.ServiceLoader} to
    * construct an instance of this provider.
    */
-  public VaultTCPSProvider() {
-    super("vault-tls", PARAMETERS);
+  public KeyVaultTCPSProvider() {
+    super("key-vault-tls", TCPS_PARAMETERS);
   }
 
   /**
-   * Retrieves an SSLContext by loading a file from OCI Vault and configuring it
-   * for secure TLS communication with Autonomous Database.
+   * Retrieves an SSLContext by loading a file from Azure Key Vault and
+   * configuring it for secure TLS communication with Autonomous Database.
    * <p>
-   * The file is stored in OCI Vault as a base64-encoded string. The type of
-   * the file
-   * (SSO, PKCS12, or PEM) must be explicitly provided, and the method
-   * processes the file
-   * data accordingly, extracting keys and certificates, and creating an
-   * SSLContext.
+   * The file is stored in Azure Key Vault as a base64-encoded string.
+   * The type of the file (SSO, PKCS12, or PEM) must be explicitly provided,
+   * and the method processes the file data accordingly, extracting keys and
+   * certificates, and creating an SSLContext.
    * </p>
    *
    * @param parameterValues The parameters required to access the file,
-   * including the OCID, password (if applicable), and file type (SSO,
-   * PKCS12, PEM).
+   * including the vault URL, the secret name, password (if applicable), and
+   * file type (SSO, PKCS12, PEM).
    * @return An initialized SSLContext for establishing secure communications.
    * @throws IllegalStateException If the SSLContext cannot be created due to
    * errors during processing.
@@ -114,14 +112,13 @@ public class VaultTCPSProvider
   public SSLContext getSSLContext(Map<Parameter, CharSequence> parameterValues) {
     try {
       ParameterSet parameterSet = parseParameterValues(parameterValues);
-      Secret secret = SecretFactory
+
+      KeyVaultSecret secret = KeyVaultSecretFactory
               .getInstance()
               .request(parameterSet)
               .getContent();
 
-      byte[] fileBytes = Base64
-              .getDecoder()
-              .decode(secret.getBase64Secret());
+      byte[] fileBytes = Base64.getDecoder().decode(secret.getValue());
 
       char[] password = parameterSet.getOptional(PASSWORD) != null
               ? parameterSet.getOptional(PASSWORD).toCharArray()
@@ -134,5 +131,4 @@ public class VaultTCPSProvider
               ("Failed to create SSLContext from the file", e);
     }
   }
-
 }

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProvider.java
@@ -1,5 +1,5 @@
 /*
- ** Copyright (c) 2023 Oracle and/or its affiliates.
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
  **
  ** The Universal Permissive License (UPL), Version 1.0
  **

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProvider.java
@@ -79,7 +79,7 @@ public class KeyVaultTCPSProvider
         implements TlsConfigurationProvider {
 
   private static final ResourceParameter[] TCPS_PARAMETERS = {
-          new ResourceParameter("password", PASSWORD),
+          new ResourceParameter("walletPassword", PASSWORD),
           new ResourceParameter("type", TYPE)
   };
 

--- a/ojdbc-provider-azure/src/main/resources/META-INF/services/oracle.jdbc.spi.PasswordProvider
+++ b/ojdbc-provider-azure/src/main/resources/META-INF/services/oracle.jdbc.spi.PasswordProvider
@@ -1,1 +1,2 @@
 oracle.jdbc.provider.azure.resource.KeyVaultPasswordProvider
+oracle.jdbc.provider.azure.resource.KeyVaultSEPSProvider

--- a/ojdbc-provider-azure/src/main/resources/META-INF/services/oracle.jdbc.spi.TlsConfigurationProvider
+++ b/ojdbc-provider-azure/src/main/resources/META-INF/services/oracle.jdbc.spi.TlsConfigurationProvider
@@ -1,0 +1,1 @@
+oracle.jdbc.provider.azure.resource.KeyVaultTCPSProvider

--- a/ojdbc-provider-azure/src/main/resources/META-INF/services/oracle.jdbc.spi.UsernameProvider
+++ b/ojdbc-provider-azure/src/main/resources/META-INF/services/oracle.jdbc.spi.UsernameProvider
@@ -1,1 +1,2 @@
 oracle.jdbc.provider.azure.resource.KeyVaultUserNameProvider
+oracle.jdbc.provider.azure.resource.KeyVaultSEPSProvider

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/AzureTestProperty.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/AzureTestProperty.java
@@ -85,9 +85,15 @@ public enum AzureTestProperty {
 
   AZURE_KEY_VAULT_SECRET_PAYLOAD_KEY,
 
+  AZURE_TLS_WALLET_SECRET_NAME,
+
   AZURE_TLS_FILE_TYPE,
 
-  AZURE_TLS_FILE_PASSWORD;
+  AZURE_TLS_FILE_PASSWORD,
+
+  AZURE_SEPS_WALLET_PASSWORD,
+
+  AZURE_SEPS_CONNECTION_STRING_INDEX, AZURE_SEPS_WALLET_SECRET_NAME;
 
   /**
    * Aborts the calling test if the given {@code names} are not configured in

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProviderTest.java
@@ -1,3 +1,41 @@
+/*
+ ** Copyright (c) 2023 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
 package oracle.jdbc.provider.azure.resource;
 
 import oracle.jdbc.provider.TestProperties;
@@ -27,7 +65,8 @@ public class KeyVaultSEPSProviderTest {
 
   /**
    * Verifies that {@link KeyVaultTCPSProvider#getParameters()}  includes parameters
-   * to configure a vault URL and secret name.
+   * to configure a vault URL, secret name, wallet password,
+   * and connection string index.
    */
   @Test
   public void testProviderParameters() {

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProviderTest.java
@@ -1,5 +1,5 @@
 /*
- ** Copyright (c) 2023 Oracle and/or its affiliates.
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
  **
  ** The Universal Permissive License (UPL), Version 1.0
  **

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProviderTest.java
@@ -1,0 +1,142 @@
+package oracle.jdbc.provider.azure.resource;
+
+import oracle.jdbc.provider.TestProperties;
+import oracle.jdbc.provider.azure.AzureTestProperty;
+import oracle.jdbc.spi.OracleResourceProvider;
+import oracle.jdbc.spi.PasswordProvider;
+import oracle.jdbc.spi.UsernameProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.createParameterValues;
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.findProvider;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class KeyVaultSEPSProviderTest {
+  private static final UsernameProvider USERNAME_PROVIDER =
+          findProvider(
+            UsernameProvider.class, "ojdbc-provider-azure-key-vault-seps");
+
+  private static final PasswordProvider PASSWORD_PROVIDER =
+          findProvider(
+            PasswordProvider.class, "ojdbc-provider-azure-key-vault-seps");
+
+  /**
+   * Verifies that {@link KeyVaultTCPSProvider#getParameters()}  includes parameters
+   * to configure a vault URL and secret name.
+   */
+  @Test
+  public void testProviderParameters() {
+    Collection<? extends OracleResourceProvider.Parameter> usernameParameters =
+            USERNAME_PROVIDER.getParameters();
+    Collection<? extends OracleResourceProvider.Parameter> passwordParameters =
+            PASSWORD_PROVIDER.getParameters();
+
+    // Verify both providers have the same parameters
+    assertEquals(usernameParameters, passwordParameters,
+            "Username and Password providers should have identical parameters");
+
+    assertNotNull(usernameParameters);
+
+    assertNotNull(passwordParameters);
+
+    OracleResourceProvider.Parameter vaultUrlParameter =
+            usernameParameters.stream()
+                    .filter(parameter -> "vaultUrl".equals(parameter.name()))
+                    .findFirst()
+                    .orElseThrow(AssertionError::new);
+    assertFalse(vaultUrlParameter.isSensitive());
+    assertTrue(vaultUrlParameter.isRequired());
+    assertNull(vaultUrlParameter.defaultValue());
+
+    OracleResourceProvider.Parameter secretNameParameter =
+            usernameParameters.stream()
+                    .filter(parameter -> "secretName".equals(parameter.name()))
+                    .findFirst()
+                    .orElseThrow(AssertionError::new);
+    assertFalse(secretNameParameter.isSensitive());
+    assertTrue(secretNameParameter.isRequired());
+    assertNull(secretNameParameter.defaultValue());
+
+    OracleResourceProvider.Parameter walletPasswordParameter =
+            usernameParameters.stream()
+                    .filter(parameter -> "walletPassword".equals(parameter.name()))
+                    .findFirst()
+                    .orElseThrow(AssertionError::new);
+    assertFalse(walletPasswordParameter.isSensitive());
+    assertFalse(walletPasswordParameter.isRequired());
+    assertNull(walletPasswordParameter.defaultValue());
+
+    OracleResourceProvider.Parameter connStringParameter =
+            usernameParameters.stream()
+                    .filter(parameter -> "connectionStringIndex".equals(parameter.name()))
+                    .findFirst()
+                    .orElseThrow(AssertionError::new);
+    assertFalse(connStringParameter.isSensitive());
+    assertFalse(connStringParameter.isRequired());
+    assertNull(connStringParameter.defaultValue());
+
+  }
+
+  @Test
+  public void testGetUsername() {
+    Map<String, String> testParameters = new HashMap<>();
+    testParameters.put(
+            "vaultUrl",
+            TestProperties.getOrAbort(AzureTestProperty.AZURE_KEY_VAULT_URL));
+    testParameters.put(
+            "secretName",
+            TestProperties.getOrAbort(AzureTestProperty.AZURE_SEPS_WALLET_SECRET_NAME));
+
+    Optional.ofNullable(TestProperties.getOptional(
+                    AzureTestProperty.AZURE_SEPS_WALLET_PASSWORD))
+            .ifPresent(password -> testParameters.put("walletPassword",
+                    password));
+
+    Optional.ofNullable(TestProperties.getOptional(
+                    AzureTestProperty.AZURE_SEPS_CONNECTION_STRING_INDEX))
+            .ifPresent(password -> testParameters.put("connectionStringIndex",
+                    password));
+
+    AzureResourceProviderTestUtil.configureAuthentication(testParameters);
+
+    Map<OracleResourceProvider.Parameter, CharSequence> parameterValues =
+            createParameterValues(USERNAME_PROVIDER, testParameters);
+
+    assertNotNull(USERNAME_PROVIDER.getUsername(parameterValues));
+
+  }
+
+  @Test
+  public void testGetPassword() {
+    Map<String, String> testParameters = new HashMap<>();
+    testParameters.put(
+            "vaultUrl",
+            TestProperties.getOrAbort(AzureTestProperty.AZURE_KEY_VAULT_URL));
+    testParameters.put(
+            "secretName",
+            TestProperties.getOrAbort(AzureTestProperty.AZURE_SEPS_WALLET_SECRET_NAME));
+
+    Optional.ofNullable(TestProperties.getOptional(
+                    AzureTestProperty.AZURE_SEPS_WALLET_PASSWORD))
+            .ifPresent(password -> testParameters.put("walletPassword",
+                    password));
+
+    Optional.ofNullable(TestProperties.getOptional(
+                    AzureTestProperty.AZURE_SEPS_CONNECTION_STRING_INDEX))
+            .ifPresent(password -> testParameters.put("connectionStringIndex",
+                    password));
+
+    AzureResourceProviderTestUtil.configureAuthentication(testParameters);
+
+    Map<OracleResourceProvider.Parameter, CharSequence> parameterValues =
+            createParameterValues(USERNAME_PROVIDER, testParameters);
+
+    assertNotNull(PASSWORD_PROVIDER.getPassword(parameterValues));
+
+  }
+}

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProviderTest.java
@@ -67,7 +67,7 @@ public class KeyVaultSEPSProviderTest {
                     .filter(parameter -> "walletPassword".equals(parameter.name()))
                     .findFirst()
                     .orElseThrow(AssertionError::new);
-    assertFalse(walletPasswordParameter.isSensitive());
+    assertTrue(walletPasswordParameter.isSensitive());
     assertFalse(walletPasswordParameter.isRequired());
     assertNull(walletPasswordParameter.defaultValue());
 

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProviderTest.java
@@ -76,7 +76,7 @@ public class KeyVaultTCPSProviderTest {
             TestProperties.getOrAbort(AzureTestProperty.AZURE_KEY_VAULT_URL));
     testParameters.put(
             "secretName",
-            TestProperties.getOrAbort(AzureTestProperty.AZURE_KEY_VAULT_SECRET_NAME));
+            TestProperties.getOrAbort(AzureTestProperty.AZURE_TLS_WALLET_SECRET_NAME));
 
     testParameters.put(
             "type",

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProviderTest.java
@@ -1,5 +1,5 @@
 /*
- ** Copyright (c) 2023 Oracle and/or its affiliates.
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
  **
  ** The Universal Permissive License (UPL), Version 1.0
  **

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProviderTest.java
@@ -1,0 +1,97 @@
+package oracle.jdbc.provider.azure.resource;
+
+import oracle.jdbc.provider.TestProperties;
+import oracle.jdbc.provider.azure.AzureTestProperty;
+import oracle.jdbc.spi.OracleResourceProvider;
+import oracle.jdbc.spi.TlsConfigurationProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.createParameterValues;
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.findProvider;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class KeyVaultTCPSProviderTest {
+  private static final TlsConfigurationProvider PROVIDER =
+          findProvider(
+            TlsConfigurationProvider.class, "ojdbc-provider-azure-key-vault-tls");
+
+  /**
+   * Verifies that {@link KeyVaultTCPSProvider#getParameters()}  includes parameters
+   * to configure a vault URL and secret name.
+   */
+  @Test
+  public void testGetParameters() {
+    Collection<? extends OracleResourceProvider.Parameter> parameters = PROVIDER.getParameters();
+    assertNotNull(parameters);
+
+    OracleResourceProvider.Parameter vaultUrlParameter =
+            parameters.stream()
+                    .filter(parameter -> "vaultUrl".equals(parameter.name()))
+                    .findFirst()
+                    .orElseThrow(AssertionError::new);
+    assertFalse(vaultUrlParameter.isSensitive());
+    assertTrue(vaultUrlParameter.isRequired());
+    assertNull(vaultUrlParameter.defaultValue());
+
+    OracleResourceProvider.Parameter secretNameParameter =
+            parameters.stream()
+                    .filter(parameter -> "secretName".equals(parameter.name()))
+                    .findFirst()
+                    .orElseThrow(AssertionError::new);
+    assertFalse(secretNameParameter.isSensitive());
+    assertTrue(secretNameParameter.isRequired());
+    assertNull(secretNameParameter.defaultValue());
+
+    OracleResourceProvider.Parameter typeParameter =
+            parameters.stream()
+                    .filter(parameter -> "type".equals(parameter.name()))
+                    .findFirst()
+                    .orElseThrow(AssertionError::new);
+    assertFalse(typeParameter.isSensitive());
+    assertTrue(typeParameter.isRequired());
+    assertNull(typeParameter.defaultValue());
+
+    OracleResourceProvider.Parameter passwordParameter =
+            parameters.stream()
+                    .filter(parameter -> "password".equals(parameter.name()))
+                    .findFirst()
+                    .orElseThrow(AssertionError::new);
+    assertTrue(passwordParameter.isSensitive());
+    assertFalse(passwordParameter.isRequired());
+    assertNull(passwordParameter.defaultValue());
+
+  }
+
+  @Test
+  public void testGetSSLContext() {
+
+    Map<String, String> testParameters = new HashMap<>();
+    testParameters.put(
+            "vaultUrl",
+            TestProperties.getOrAbort(AzureTestProperty.AZURE_KEY_VAULT_URL));
+    testParameters.put(
+            "secretName",
+            TestProperties.getOrAbort(AzureTestProperty.AZURE_KEY_VAULT_SECRET_NAME));
+
+    testParameters.put(
+            "type",
+            TestProperties.getOrAbort(AzureTestProperty.AZURE_TLS_FILE_TYPE));
+
+    Optional.ofNullable(TestProperties.getOptional(
+                    AzureTestProperty.AZURE_TLS_FILE_PASSWORD))
+            .ifPresent(password -> testParameters.put("password",
+                    password));
+
+    AzureResourceProviderTestUtil.configureAuthentication(testParameters);
+
+    Map<OracleResourceProvider.Parameter, CharSequence> parameterValues =
+            createParameterValues(PROVIDER, testParameters);
+    assertNotNull(PROVIDER.getSSLContext(parameterValues));
+
+  }
+}

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProviderTest.java
@@ -1,3 +1,41 @@
+/*
+ ** Copyright (c) 2023 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
 package oracle.jdbc.provider.azure.resource;
 
 import oracle.jdbc.provider.TestProperties;
@@ -22,7 +60,7 @@ public class KeyVaultTCPSProviderTest {
 
   /**
    * Verifies that {@link KeyVaultTCPSProvider#getParameters()}  includes parameters
-   * to configure a vault URL and secret name.
+   * to configure a vault URL, secret name, wallet password, and type.
    */
   @Test
   public void testGetParameters() {

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProviderTest.java
@@ -56,14 +56,14 @@ public class KeyVaultTCPSProviderTest {
     assertTrue(typeParameter.isRequired());
     assertNull(typeParameter.defaultValue());
 
-    OracleResourceProvider.Parameter passwordParameter =
+    OracleResourceProvider.Parameter walletPasswordParameter =
             parameters.stream()
-                    .filter(parameter -> "password".equals(parameter.name()))
+                    .filter(parameter -> "walletPassword".equals(parameter.name()))
                     .findFirst()
                     .orElseThrow(AssertionError::new);
-    assertTrue(passwordParameter.isSensitive());
-    assertFalse(passwordParameter.isRequired());
-    assertNull(passwordParameter.defaultValue());
+    assertTrue(walletPasswordParameter.isSensitive());
+    assertFalse(walletPasswordParameter.isRequired());
+    assertNull(walletPasswordParameter.defaultValue());
 
   }
 
@@ -84,7 +84,7 @@ public class KeyVaultTCPSProviderTest {
 
     Optional.ofNullable(TestProperties.getOptional(
                     AzureTestProperty.AZURE_TLS_FILE_PASSWORD))
-            .ifPresent(password -> testParameters.put("password",
+            .ifPresent(password -> testParameters.put("walletPassword",
                     password));
 
     AzureResourceProviderTestUtil.configureAuthentication(testParameters);

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/CommonParameters.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/CommonParameters.java
@@ -1,0 +1,114 @@
+/*
+ ** Copyright (c) 2023 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.jdbc.provider.util;
+
+import oracle.jdbc.provider.parameter.Parameter;
+
+import static oracle.jdbc.provider.parameter.Parameter.CommonAttribute.REQUIRED;
+
+/**
+ * A utility class that defines common parameters used across various
+ * resource providers for Oracle JDBC.
+ * This class contains predefined parameters such as the type of wallet file,
+ * password, and connection string index, which are used to configure resource
+ * providers that interact with secure storage and retrieve credentials or keys.
+ *
+ */
+public final class CommonParameters {
+
+  private CommonParameters() {}
+
+  /**
+   * A parameter for specifying the password used to decrypt the file if it is
+   * password-protected. The password is necessary for PKCS12 and encrypted
+   * PEM files.
+   * If the file is not encrypted (e.g., SSO format or non password-protected
+   * PEM), this parameter can be {@code null}. It is
+   * only required when dealing with password-protected files.
+   */
+  public static final Parameter<String> PASSWORD =
+          Parameter.create();
+
+  /**
+   * A parameter for specifying the type of the file being used.
+   * This parameter defines the format of the file and dictates how it
+   * should be processed.
+   * The acceptable values are:
+   * <ul>
+   *     <li>{@code SSO} - For Single Sign-On format.</li>
+   *     <li>{@code PKCS12} - For PKCS12 keystore format, which may be
+   *     password-protected.</li>
+   *     <li>{@code PEM} - For PEM-encoded format, which may include
+   *     encrypted or unencrypted private keys and certificates.</li>
+   * </ul>
+   *
+   * The type parameter is required to correctly parse and handle the file
+   * data.
+   */
+  public static final Parameter<String> TYPE =
+    Parameter.create(REQUIRED);
+
+  /**
+   * A parameter for specifying the connection string index in cases where
+   * multiple connection strings are stored in a wallet.
+   * This parameter allows selecting a specific set of credentials based on the
+   * indexed connection string in the Secure External Password Store (SEPS)
+   * wallet. If multiple connection strings are present, this parameter helps to
+   * disambiguate which connection string and its associated credentials should
+   * be used.
+   * For example, if the SEPS wallet contains multiple connection strings, such as:
+   * <ul>
+   *     <li>{@code oracle.security.client.connect_string1}</li>
+   *     <li>{@code oracle.security.client.username1}</li>
+   *     <li>{@code oracle.security.client.password1}</li>
+   *     <li>{@code oracle.security.client.connect_string2}</li>
+   *     <li>{@code oracle.security.client.username2}</li>
+   *     <li>{@code oracle.security.client.password2}</li>
+   * </ul>
+   * The {@code connectionStringIndex} can be set to {@code 1} or {@code 2} to
+   * select the appropriate credential set.
+   * If this parameter is {@code null}, the provider will attempt to use default
+   * credentials or the first connection string if only one is present in the wallet.
+   * If multiple connection strings exist and this parameter is not set, an error
+   * will be thrown to avoid ambiguity.
+   */
+  public static final Parameter<String> CONNECTION_STRING_INDEX =
+    Parameter.create();
+
+}

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/CommonParameters.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/CommonParameters.java
@@ -1,5 +1,5 @@
 /*
- ** Copyright (c) 2023 Oracle and/or its affiliates.
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
  **
  ** The Universal Permissive License (UPL), Version 1.0
  **

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/CommonParameters.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/CommonParameters.java
@@ -41,6 +41,7 @@ package oracle.jdbc.provider.util;
 import oracle.jdbc.provider.parameter.Parameter;
 
 import static oracle.jdbc.provider.parameter.Parameter.CommonAttribute.REQUIRED;
+import static oracle.jdbc.provider.parameter.Parameter.CommonAttribute.SENSITIVE;
 
 /**
  * A utility class that defines common parameters used across various
@@ -63,7 +64,7 @@ public final class CommonParameters {
    * only required when dealing with password-protected files.
    */
   public static final Parameter<String> PASSWORD =
-          Parameter.create();
+          Parameter.create(SENSITIVE);
 
   /**
    * A parameter for specifying the type of the file being used.

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/ResourceParameterUtils.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/ResourceParameterUtils.java
@@ -36,76 +36,35 @@
  ** SOFTWARE.
  */
 
-package oracle.jdbc.provider.azure;
+package oracle.jdbc.provider.util;
 
-import com.azure.core.util.Configuration;
+import oracle.jdbc.provider.resource.ResourceParameter;
 
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import java.util.stream.Stream;
 
 /**
- * Names of properties that configure Azure tests. Descriptions and examples of
- * each property can be found in the "example-test.properties" file within the
- * root directory of the project.
+ * A utility class for manipulating {@link ResourceParameter} arrays.
  */
-public enum AzureTestProperty {
+public final class ResourceParameterUtils {
 
-  AZURE_TENANT_ID,
-
-  AZURE_CLIENT_ID,
-
-  AZURE_CLIENT_SECRET,
-
-  AZURE_CLIENT_CERTIFICATE_PATH,
-
-  AZURE_CLIENT_PFX_CERTIFICATE_PATH,
-
-  AZURE_CLIENT_PFX_PASSWORD,
-
-  AZURE_USERNAME,
-
-  AZURE_PASSWORD,
-
-  AZURE_MANAGED_IDENTITY,
-
-  AZURE_APP_CONFIG_NAME,
-
-  AZURE_APP_CONFIG_KEY,
-
-  AZURE_APP_CONFIG_LABEL,
-
-  AZURE_TOKEN_SCOPE,
-
-  AZURE_KEY_VAULT_URL,
-
-  AZURE_KEY_VAULT_SECRET_NAME,
-
-  AZURE_KEY_VAULT_SECRET_PAYLOAD_NAME,
-
-  AZURE_KEY_VAULT_SECRET_PAYLOAD_NAME_MULTIPLE_KEYS,
-
-  AZURE_KEY_VAULT_SECRET_PAYLOAD_KEY,
-
-  AZURE_TLS_FILE_TYPE,
-
-  AZURE_TLS_FILE_PASSWORD;
+  private ResourceParameterUtils() {}
 
   /**
-   * Aborts the calling test if the given {@code names} are not configured in
-   * the environment read by the Azure SDK.
-   * @param names Names of configurable values that the Azure SDK reads from the
-   * environment.
+   * Combines two arrays of resource parameters into a single array.
+   * This method is useful when you need to merge parameters from different
+   * sources into a unified set.
+   *
+   * @param baseParams The first array of resource parameters to combine.
+   * @param additionalParams The second array of resource parameters to combine.
+   * @return A new array containing all elements from both input arrays.
+   *
    */
-  public static void abortIfEnvNotConfigured(String... names) {
-    Configuration configuration = Configuration.getGlobalConfiguration();
-
-    for (String name : names) {
-      assumeTrue(
-        configuration.contains(name),
-        String.format(
-          "\"%s\" is not configured in the environment read by the" +
-            " Azure SDK for Java",
-          name));
-    }
+  public static ResourceParameter[] combineParameters(
+          ResourceParameter[] baseParams, ResourceParameter[] additionalParams) {
+    return Stream.concat(
+                    Stream.of(baseParams),
+                    Stream.of(additionalParams))
+            .toArray(ResourceParameter[]::new);
   }
 
 }

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/ResourceParameterUtils.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/ResourceParameterUtils.java
@@ -1,5 +1,5 @@
 /*
- ** Copyright (c) 2023 Oracle and/or its affiliates.
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
  **
  ** The Universal Permissive License (UPL), Version 1.0
  **

--- a/ojdbc-provider-oci/example-test.properties
+++ b/ojdbc-provider-oci/example-test.properties
@@ -128,3 +128,21 @@ OCI_DB_TOOLS_CONNECTION_OCID_PKCS12=ocid1.databasetoolsconnection.oc1.phx.aaaaaa
 
 # The OCID of a Database Tools Connection with the SSO Wallet
 OCI_DB_TOOLS_CONNECTION_OCID_SSO=ocid1.databasetoolsconnection.oc1.phx.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+# The OCID of a TCPS (TLS) Wallet stored in OCI Vault for secure communication
+OCI_TLS_WALLET_OCID=ocid1.vaultsecret.oc1.phx.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+# Optional password for the TLS Wallet stored in OCI Vault
+OCI_TLS_WALLET_PASSWORD=******
+
+# The file type of the TLS Wallet (SSO, PKCS12, PEM)
+OCI_TLS_FILE_TYPE=PKCS12
+
+# The OCID of a SEPS Wallet stored in OCI Vault
+OCI_SEPS_WALLET_OCID=ocid1.vaultsecret.oc1.phx.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+# Optional password for the SEPS Wallet stored in OCI Vault
+OCI_SEPS_WALLET_PASSWORD=*****
+
+# Optional index to select specific credentials from SEPS Wallet
+OCI_SEPS_CONNECTION_STRING_INDEX=1

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/resource/VaultSEPSProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/resource/VaultSEPSProvider.java
@@ -51,6 +51,8 @@ import java.util.Base64;
 import java.util.Map;
 
 import static oracle.jdbc.provider.oci.vault.SecretFactory.OCID;
+import static oracle.jdbc.provider.util.CommonParameters.CONNECTION_STRING_INDEX;
+import static oracle.jdbc.provider.util.CommonParameters.PASSWORD;
 
 /**
  * <p>
@@ -75,12 +77,6 @@ import static oracle.jdbc.provider.oci.vault.SecretFactory.OCID;
 public class VaultSEPSProvider
         extends OciResourceProvider
         implements UsernameProvider, PasswordProvider {
-
-  private static final oracle.jdbc.provider.parameter.Parameter<String> PASSWORD =
-          oracle.jdbc.provider.parameter.Parameter.create();
-
-  private static final oracle.jdbc.provider.parameter.Parameter<String> CONNECTION_STRING_INDEX =
-          oracle.jdbc.provider.parameter.Parameter.create();
 
 
   private static final ResourceParameter[] PARAMETERS = {


### PR DESCRIPTION
This PR adds support for TCPS Wallet Provider and SEPS (Secure External Password Store) Wallet Provider for Azure Key Vault, enhancing security for Oracle JDBC connections in Azure environments. The TCPS Wallet Provider enables secure retrieval and management of Base64-encoded wallets (PKCS12, SSO and PEM) from Azure Key Vault for mutual TLS (mTLS) communication with Oracle Autonomous Database. The SEPS Wallet Provider retrieves SEPS wallets from Azure Key Vault, securely extracting database credentials. These features extend Oracle JDBC’s functionality in Azure, similar to what is available for OCI Vault.

Fixes Issue: #102 