### PR TITLE
Azure Key Vault Connection String Provider and Refactoring of Secret Retrieval

### DIFF
--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -28,6 +28,8 @@ This module contains providers for integration between Oracle JDBC and Azure.
 <dd>Provides TCPS/TLS wallet for secure connections to an Autonomous Database from the Key Vault service</dd>
 <dt><a href="#key-vault-seps-wallet-provider">Key Vault SEPS Wallet Provider</a></dt>
 <dd>Provides SEPS (Secure External Password Store) wallets for secure username and password retrieval from the Key Vault service</dd> 
+<dt><a href="#key-vault-connection-string-provider">Key Vault Connection String Provider</a></dt>
+<dd>Provides connection strings for secure database connectivity based on consumer groups, retrieved from the tnsnames.ora file stored in Azure Key Vault.</dd> 
 <dt><a href="#common-parameters-for-resource-providers">Common Parameters for Resource Providers</a></dt>
 <dd>Common parameters supported by the resource providers</dd>
 </dl>
@@ -506,6 +508,51 @@ Optional parameter to specify the index of the connection string to use when ret
 </table>
 
 An example of a [connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE) that configures this provider can be found in [example-key-vault-wallet.properties](example-key-vault-wallet.properties).
+
+## Key Vault Connection String Provider
+
+The Key Vault Connection String Provider provides Oracle JDBC with a connection string managed by the Azure Key Vault service.
+This is a Resource Provider identified by the name `ojdbc-provider-azure-key-vault-tnsnames`.
+
+This provider retrieves and decodes a `tnsnames.ora` file stored as a base64-encoded secret. in Azure Key Vault, allowing selection of
+connection strings based on predefined consumer groups such as `HIGH`, `MEDIUM`, `LOW`, `TRANSACTION_PROCESSING`,
+and `TRANSACTION_PROCESSING_URGENT`.For more details, refer to the official Oracle documentation on [Consumer Groups and Database Service Levels](https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/manage-priorities.html#GUID-6CEFC4B7-6EF8-4237-A004-C88F570A480B).
+
+This enables flexible configuration for secure database connections based on workload and concurrency requirements.
+
+In addition to the set of [common parameters](#common-parameters-for-resource-providers), this provider also supports the parameters listed below.
+
+<table>
+<thead>
+  <tr>
+    <th>Parameter Name</th>
+    <th>Description</th>
+    <th>Accepted Values</th>
+    <th>Default Value</th>
+  </tr>
+</thead>
+<tbody> 
+  <tr> <td>vaultUrl</td> 
+    <td>The URL of the Azure Key Vault containing the tnsnames.ora file.</td> 
+    <td> The <a href="https://docs.microsoft.com/en-us/azure/key-vault/general/overview">Azure Key Vault URL</a>, typically in the form: <pre>https://{vault-name}.vault.azure.net/</pre> </td> 
+    <td> <i>No default value. A value must be configured for this parameter.</i> </td> 
+  </tr> 
+  <tr>
+    <td>secretName</td> 
+    <td>The name of the secret containing the tnsnames.ora file in Azure Key Vault.</td> 
+    <td>Any valid secret name</td> 
+    <td> <i>No default value. A value must be configured for this parameter.</i> </td>
+  </tr>
+  <tr>
+    <td>consumerGroup</td>
+    <td>Specifies the consumer group to retrieve the appropriate connection string from the tnsnames.ora file.</td> 
+    <td>HIGH, MEDIUM, LOW, TRANSACTION_PROCESSING, TRANSACTION_PROCESSING_URGENT</td>
+    <td>MEDIUM</td> 
+  </tr> 
+</tbody>
+</table>
+
+An example of a [connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE) that configures this provider can be found in [example-key-vault.properties](example-key-vault.properties).
 
 ## Common Parameters for Resource Providers
 Providers classified as Resource Providers in this module all support a

--- a/ojdbc-provider-azure/example-key-vault.properties
+++ b/ojdbc-provider-azure/example-key-vault.properties
@@ -56,3 +56,12 @@ oracle.jdbc.provider.username.secretName=${USERNAME_SECRET_NAME}
 oracle.jdbc.provider.password=ojdbc-provider-azure-key-vault-password
 oracle.jdbc.provider.password.vaultUrl=${KEY_VAULT_URL}
 oracle.jdbc.provider.password.secretName=${PASSWORD_SECRET_NAME}
+
+# Configures the Azure Key Vault Connection String Provider. The vault URL, secret name,
+# and consumer group are configured as environment variables or JVM system properties
+# named "KEY_VAULT_URL", "TNSNAMES_SECRET_NAME", and "CONSUMER_GROUP".
+oracle.jdbc.provider.connectionString=ojdbc-provider-azure-key-vault-tnsnames
+oracle.jdbc.provider.connectionString.vaultUrl=${KEY_VAULT_URL}
+oracle.jdbc.provider.connectionString.secretName=${TNSNAMES_SECRET_NAME}
+oracle.jdbc.provider.connectionString.consumer-group=${CONSUMER_GROUP}
+

--- a/ojdbc-provider-azure/example-test.properties
+++ b/ojdbc-provider-azure/example-test.properties
@@ -143,3 +143,10 @@ AZURE_SEPS_WALLET_PASSWORD=*****
 
 # Optional index to select specific credentials from SEPS wallet
 AZURE_SEPS_CONNECTION_STRING_INDEX=1
+
+# The name of the Key Vault secret containing the base64-encoded tnsnames.ora file
+AZURE_TNSNAMES_SECRET_NAME=example-tnsnames-secret-name
+
+# The consumer group in the tnsnames.ora file to use for the connection string
+# Available values include HIGH, MEDIUM, LOW, TRANSACTION_PROCESSING, TRANSACTION_PROCESSING_URGENT
+AZURE_TNS_NAMES_CONSUMER_GROUP=MEDIUM

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultConnectionStringProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultConnectionStringProvider.java
@@ -1,0 +1,145 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.jdbc.provider.azure.resource;
+
+import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import oracle.jdbc.provider.azure.keyvault.KeyVaultSecretFactory;
+import oracle.jdbc.provider.parameter.ParameterSet;
+import oracle.jdbc.provider.resource.ResourceParameter;
+import oracle.jdbc.provider.util.TNSNames;
+import oracle.jdbc.spi.ConnectionStringProvider;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.Map;
+
+import static oracle.jdbc.provider.util.CommonParameters.CONSUMER_GROUP;
+
+
+/**
+ * <p>
+ * A provider for securely retrieving the connection string from a tnsnames.ora
+ * file stored in Azure Key Vault for use with an Oracle Autonomous Database.
+ * The tnsnames.ora file is stored as a base64-encoded secret in Azure Key Vault
+ * and is decoded, parsed, and used to select connection strings based on
+ * predefined Consumer Groups (e.g., HIGH, MEDIUM, LOW, TRANSACTION_PROCESSING,
+ * TRANSACTION_PROCESSING_URGENT).
+ * </p>
+ * <p>
+ * This class implements the {@link ConnectionStringProvider} SPI defined by
+ * Oracle JDBC.
+ * It is designed to be instantiated via {@link java.util.ServiceLoader}.
+ * </p>
+ *
+ */
+public class KeyVaultConnectionStringProvider
+        extends KeyVaultSecretProvider
+        implements ConnectionStringProvider {
+
+  private static final ResourceParameter[] CONSUMER_GROUP_PARAMETERS = {
+          new ResourceParameter("consumer-group", CONSUMER_GROUP, "MEDIUM")
+  };
+
+  /**
+   * A public no-arg constructor used by {@link java.util.ServiceLoader} to
+   * construct an instance of this provider.
+   */
+  public KeyVaultConnectionStringProvider() {
+    super("key-vault-tnsnames", CONSUMER_GROUP_PARAMETERS);
+  }
+
+  /**
+   * Retrieves a database connection string from the tnsnames.ora file stored
+   * in Azure Key Vault.
+   * <p>
+   * This method accesses the file in Azure Key Vault, decodes it if stored
+   * in base64 format, and parses the tnsnames.ora content. It returns the
+   * connection string for a specified consumer group (e.g., HIGH, MEDIUM,
+   * LOW, TRANSACTION_PROCESSING, TRANSACTION_PROCESSING_URGENT) to allow
+   * flexible connection configuration.
+   * </p>
+   *
+   * @param parameterValues The parameters required to access the tnsnames.ora
+   * file in Azure Key Vault, including the vault URL, the secret name, and
+   * the consumer group.
+   * @return The connection string associated with the specified consumer group
+   * in the tnsnames.ora file.
+   * @throws IllegalStateException If the connection string cannot be retrieved
+   * or the consumer group is invalid.
+   */
+  @Override
+  public String getConnectionString(Map<Parameter, CharSequence> parameterValues) {
+    try {
+      ParameterSet parameterSet = parseParameterValues(parameterValues);
+
+      // Retrieve the secret containing tnsnames.ora content from Azure Key Vault
+      KeyVaultSecret secret = KeyVaultSecretFactory
+              .getInstance()
+              .request(parameterSet)
+              .getContent();
+
+      // Decode the base64-encoded tnsnames.ora content
+      byte[] fileBytes = Base64.getDecoder().decode(secret.getValue());
+
+      TNSNames tnsNames;
+      try (InputStream inputStream = new ByteArrayInputStream(fileBytes)) {
+        tnsNames = TNSNames.read(inputStream);
+      }
+
+      TNSNames.ConsumerGroup consumerGroup = TNSNames.ConsumerGroup.valueOf(
+              parameterSet
+                .getRequired(CONSUMER_GROUP)
+                .toUpperCase(Locale.ENGLISH));
+
+      // Retrieve the connection string for the specified consumer group
+      String connectionString = tnsNames.getConnectionString(consumerGroup);
+
+      if (connectionString == null) {
+        throw new IllegalArgumentException(
+                "Unrecognized or unavailable consumer group: " + consumerGroup);
+      }
+
+      return connectionString;
+
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to retrieve connection string", e);
+    }
+  }
+}

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultSEPSProvider.java
@@ -38,8 +38,6 @@
 
 package oracle.jdbc.provider.azure.resource;
 
-import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
-import oracle.jdbc.provider.azure.keyvault.KeyVaultSecretFactory;
 import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.provider.resource.ResourceParameter;
 import oracle.jdbc.provider.util.WalletUtils;
@@ -87,19 +85,19 @@ public class KeyVaultSEPSProvider
    */
   private WalletUtils.Credentials getWalletCredentials(
           Map<OracleResourceProvider.Parameter, CharSequence> parameterValues) {
-
     ParameterSet parameterSet = parseParameterValues(parameterValues);
-    KeyVaultSecret secret = KeyVaultSecretFactory
-            .getInstance()
-            .request(parameterSet)
-            .getContent();
+
+    // Retrieve the secret containing the wallet content from Azure Key Vault
+    String secretValue = getSecret(parameterValues);
+
+    // Decode the base64-encoded wallet content
+    byte[] walletBytes = Base64.getDecoder().decode(secretValue);
 
     char[] walletPassword = parameterSet.getOptional(PASSWORD) != null
             ? parameterSet.getOptional(PASSWORD).toCharArray()
             : null;
 
     String connectionStringIndex = parameterSet.getOptional(CONNECTION_STRING_INDEX);
-    byte[] walletBytes = Base64.getDecoder().decode(secret.getValue());
     return WalletUtils.getCredentials(walletBytes, walletPassword, connectionStringIndex);
   }
 

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultTCPSProvider.java
@@ -38,8 +38,6 @@
 
 package oracle.jdbc.provider.azure.resource;
 
-import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
-import oracle.jdbc.provider.azure.keyvault.KeyVaultSecretFactory;
 import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.provider.resource.ResourceParameter;
 import oracle.jdbc.provider.util.TlsUtils;
@@ -113,12 +111,9 @@ public class KeyVaultTCPSProvider
     try {
       ParameterSet parameterSet = parseParameterValues(parameterValues);
 
-      KeyVaultSecret secret = KeyVaultSecretFactory
-              .getInstance()
-              .request(parameterSet)
-              .getContent();
+      String secretValue = getSecret(parameterValues);
 
-      byte[] fileBytes = Base64.getDecoder().decode(secret.getValue());
+      byte[] fileBytes = Base64.getDecoder().decode(secretValue);
 
       char[] password = parameterSet.getOptional(PASSWORD) != null
               ? parameterSet.getOptional(PASSWORD).toCharArray()

--- a/ojdbc-provider-azure/src/main/resources/META-INF/services/oracle.jdbc.spi.ConnectionStringProvider
+++ b/ojdbc-provider-azure/src/main/resources/META-INF/services/oracle.jdbc.spi.ConnectionStringProvider
@@ -1,0 +1,1 @@
+oracle.jdbc.provider.azure.resource.KeyVaultConnectionStringProvider

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/AzureTestProperty.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/AzureTestProperty.java
@@ -109,7 +109,7 @@ public enum AzureTestProperty {
 
   AZURE_TNS_NAMES_SECRET_NAME,
 
-  AZURE_CONSUMER_GROUP;
+  AZURE_TNS_NAMES_CONSUMER_GROUP;
 
   /**
    * Aborts the calling test if the given {@code names} are not configured in

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/AzureTestProperty.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/AzureTestProperty.java
@@ -105,7 +105,11 @@ public enum AzureTestProperty {
 
   AZURE_CORRUPTED_SEPS_WALLET_SECRET_NAME,
 
-  AZURE_SEPS_CONNECTION_STRING_INDEX;
+  AZURE_SEPS_CONNECTION_STRING_INDEX,
+
+  AZURE_TNS_NAMES_SECRET_NAME,
+
+  AZURE_CONSUMER_GROUP;
 
   /**
    * Aborts the calling test if the given {@code names} are not configured in

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultConnectionStringProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultConnectionStringProviderTest.java
@@ -126,7 +126,7 @@ public class KeyVaultConnectionStringProviderTest {
 
     testParameters.put(
       "consumer-group",
-       TestProperties.getOrAbort(AzureTestProperty.AZURE_CONSUMER_GROUP));
+       TestProperties.getOrAbort(AzureTestProperty.AZURE_TNS_NAMES_CONSUMER_GROUP));
 
     AzureResourceProviderTestUtil.configureAuthentication(testParameters);
     Map<Parameter, CharSequence> parameterValues = createParameterValues(PROVIDER, testParameters);

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultConnectionStringProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultConnectionStringProviderTest.java
@@ -1,0 +1,120 @@
+/*
+ ** Copyright (c) 2023 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.jdbc.provider.azure.resource;
+
+import oracle.jdbc.provider.TestProperties;
+import oracle.jdbc.provider.azure.AzureTestProperty;
+import oracle.jdbc.spi.ConnectionStringProvider;
+import oracle.jdbc.spi.OracleResourceProvider.Parameter;
+import oracle.jdbc.spi.UsernameProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.createParameterValues;
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.findProvider;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class KeyVaultConnectionStringProviderTest {
+
+  private static final ConnectionStringProvider PROVIDER =
+    findProvider(
+      ConnectionStringProvider.class, "ojdbc-provider-azure-key-vault-tnsnames");
+
+  /**
+   * Verifies that {@link UsernameProvider#getParameters()} includes parameters
+   * to configure a vault URL and secret name.
+   */
+  @Test
+  public void testGetParameters() {
+    Collection<? extends Parameter> parameters = PROVIDER.getParameters();
+    assertNotNull(parameters);
+
+    Parameter vaultUrlParameter =
+      parameters.stream()
+        .filter(parameter -> "vaultUrl".equals(parameter.name()))
+        .findFirst()
+        .orElseThrow(AssertionError::new);
+    assertFalse(vaultUrlParameter.isSensitive());
+    assertTrue(vaultUrlParameter.isRequired());
+    assertNull(vaultUrlParameter.defaultValue());
+
+    Parameter secretNameParameter =
+      parameters.stream()
+        .filter(parameter -> "secretName".equals(parameter.name()))
+        .findFirst()
+        .orElseThrow(AssertionError::new);
+    assertFalse(secretNameParameter.isSensitive());
+    assertTrue(secretNameParameter.isRequired());
+    assertNull(secretNameParameter.defaultValue());
+
+  }
+
+  /**
+   * Verifies that {@link UsernameProvider#getUsername(Map)} returns the
+   * username identified by a vault URL and secret name.
+   */
+  @Test
+  public void testGetConnectionString() {
+
+    Map<String, String> testParameters = new HashMap<>();
+    testParameters.put(
+      "vaultUrl",
+      TestProperties.getOrAbort(AzureTestProperty.AZURE_KEY_VAULT_URL));
+    testParameters.put(
+      "secretName",
+      TestProperties.getOrAbort(AzureTestProperty.AZURE_TNS_NAMES_SECRET_NAME));
+
+    testParameters.put(
+            "consumer-group",
+            TestProperties.getOrAbort(AzureTestProperty.AZURE_CONSUMER_GROUP));
+
+    AzureResourceProviderTestUtil.configureAuthentication(testParameters);
+
+    Map<Parameter, CharSequence> parameterValues =
+      createParameterValues(PROVIDER, testParameters);
+
+    System.out.println(PROVIDER.getConnectionString(parameterValues));
+
+    assertNotNull(PROVIDER.getConnectionString(parameterValues));
+  }
+
+}

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/CommonParameters.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/CommonParameters.java
@@ -112,4 +112,44 @@ public final class CommonParameters {
   public static final Parameter<String> CONNECTION_STRING_INDEX =
     Parameter.create();
 
+  /**
+   * <p>
+   * A parameter for specifying the consumer group to be used for connecting
+   * to an Oracle Autonomous Database.
+   * This consumer group determines the level of concurrency, prioritization,
+   * and performance for database connections.
+   * </p>
+   *
+   * <p><b>Supported Consumer Groups:</b></p>
+   * <ul>
+   *     <li>
+   *       <b>HIGH:</b> Typically used for workloads that require higher
+   *       concurrency limits.
+   *     </li>
+   *     <li>
+   *       <b>MEDIUM:</b> Default consumer group for balanced performance
+   *       and concurrency.
+   *     </li>
+   *     <li>
+   *       <b>LOW:</b> Lower priority with typically higher concurrency limits
+   *       suitable for non-critical workloads.
+   *     </li>
+   *     <li>
+   *       <b>TP:</b> Optimized for transaction processing, providing a balance
+   *       between concurrency and response time.
+   *     </li>
+   *     <li>
+   *       <b>TPURGENT:</b> Highest priority consumer group intended for urgent
+   *       transaction processing requirements.
+   *     </li>
+   * </ul>
+   *
+   * <p>The choice of consumer group allows users to align database connection
+   * priorities and concurrency levels with the specific requirements of
+   * their workload.
+   * If no consumer group is specified, MEDIUM is typically used as the default.
+   * </p>
+   */
+  public static final Parameter<String> CONSUMER_GROUP = Parameter.create();
+
 }

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/TNSNames.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/TNSNames.java
@@ -36,7 +36,7 @@
  ** SOFTWARE.
  */
 
-package oracle.jdbc.provider.oci.database;
+package oracle.jdbc.provider.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -60,7 +60,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * and use the information to establish a network connection with an ADB
  * instance.
  */
-final class TNSNames {
+public final class TNSNames {
 
   /**
    * Maximum size, in bytes, of a connection string.
@@ -94,7 +94,7 @@ final class TNSNames {
    * @return The connection string for the {@code consumerGroup}, or null if
    * none is defined.
    */
-  String getConnectionString(ConsumerGroup consumerGroup) {
+  public String getConnectionString(ConsumerGroup consumerGroup) {
     return connectionStrings.get(consumerGroup);
   }
 
@@ -105,7 +105,7 @@ final class TNSNames {
    * And here:
    * https://docs.oracle.com/en/database/oracle/oracle-database/23/netrf/local-naming-parameters-in-tns-ora-file.html#GUID-47DAB4DF-1D35-46E5-B227-339FF912E058
    */
-  static TNSNames read(InputStream inputStream) {
+  public static TNSNames read(InputStream inputStream) {
 
     BufferedReader reader =
         new BufferedReader(new InputStreamReader(inputStream, UTF_8));
@@ -217,7 +217,7 @@ final class TNSNames {
    * file. These groups are pre-defined for each type of ADB workload type:
    * https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/connect-predefined-generic.html#GUID-E49773B3-6C07-4F6F-906B-42705D237523
    */
-  enum ConsumerGroup {
+  public enum ConsumerGroup {
     HIGH("high"),
     MEDIUM("medium"),
     LOW("low"),

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
@@ -36,9 +36,7 @@
  ** SOFTWARE.
  */
 
-package oracle.jdbc.provider.oci.database;
-
-import oracle.jdbc.provider.util.TlsUtils;
+package oracle.jdbc.provider.util;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
@@ -167,7 +165,7 @@ public final class Wallet {
    * @throws IllegalStateException If the files are not found or can not be
    * decoded.
    */
-  static Wallet unzip(ZipInputStream zipStream, char[] password) {
+  public static Wallet unzip(ZipInputStream zipStream, char[] password) {
 
     TNSNames tnsNames = null;
     KeyStore keyStore = null;

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/database/WalletFactory.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/database/WalletFactory.java
@@ -49,6 +49,7 @@ import oracle.jdbc.provider.oci.OciResourceFactory;
 import oracle.jdbc.provider.parameter.Parameter;
 import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.provider.factory.Resource;
+import oracle.jdbc.provider.util.Wallet;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/resource/DatabaseConnectionStringProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/resource/DatabaseConnectionStringProvider.java
@@ -38,14 +38,16 @@
 
 package oracle.jdbc.provider.oci.resource;
 
-import oracle.jdbc.provider.oci.database.Wallet;
 import oracle.jdbc.provider.oci.database.WalletFactory;
 import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.provider.resource.ResourceParameter;
+import oracle.jdbc.provider.util.Wallet;
 import oracle.jdbc.spi.ConnectionStringProvider;
 
 import java.util.Locale;
 import java.util.Map;
+
+import static oracle.jdbc.provider.util.CommonParameters.CONSUMER_GROUP;
 
 /**
  * <p>
@@ -60,9 +62,6 @@ import java.util.Map;
 public final class DatabaseConnectionStringProvider
   extends OciResourceProvider
   implements ConnectionStringProvider {
-
-  private static final oracle.jdbc.provider.parameter.Parameter<String>
-    CONSUMER_GROUP = oracle.jdbc.provider.parameter.Parameter.create();
 
   private static final ResourceParameter[] PARAMETERS =
     new ResourceParameter[] {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/SimpleConnectionStringProviderAzureExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/SimpleConnectionStringProviderAzureExample.java
@@ -1,0 +1,101 @@
+/*
+ ** Copyright (c) 2024 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+package oracle.jdbc.provider.azure.configuration.resource;
+
+import oracle.jdbc.datasource.impl.OracleDataSource;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * Example demonstrating how to configure Oracle JDBC with the Key Vault
+ * Connection String Provider to retrieve connection strings from a tnsnames.ora
+ * file stored in Azure Key Vault.
+ */
+public class SimpleConnectionStringProviderAzureExample {
+  public static void main(String[] args) throws SQLException {
+    try {
+      OracleDataSource ds = new OracleDataSource();
+      ds.setURL("jdbc:oracle:thin:@");
+
+      Properties connectionProps = new Properties();
+
+      // Connection String Provider for retrieving tnsnames.ora content
+      // from Key Vault in Azure
+      connectionProps.put("oracle.jdbc.provider.connectionString",
+        "ojdbc-provider-azure-key-vault-tnsnames");
+
+      connectionProps.put("oracle.jdbc.provider.connectionString.vaultUrl",
+        "https://your-vault-url.vault.azure.net");
+      connectionProps.put("oracle.jdbc.provider.connectionString.secretName",
+        "your-tnsnames-secret-name");
+
+      // Specify the consumer group to retrieve the corresponding connection string
+      connectionProps.put("oracle.jdbc.provider.connectionString.consumerGroup",
+        "MEDIUM");
+
+      // TLS Configuration for secure connection
+      connectionProps.put("oracle.jdbc.provider.tlsConfiguration", "ojdbc-provider-azure-key-vault-tls");
+      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.vaultUrl",
+              "https://your-vault-url.vault.azure.net");
+      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.secretName",
+              "your-wallet-base64-secret-name");
+      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.type",
+              "SSO");
+
+      ds.setConnectionProperties(connectionProps);
+
+      try (Connection cn = ds.getConnection()) {
+        String connectionString = cn.getMetaData().getURL();
+        System.out.println("Connected to: " + connectionString);
+
+        Statement st = cn.createStatement();
+        ResultSet rs = st.executeQuery("SELECT 'Hello, db' FROM sys.dual");
+        if (rs.next()) {
+          System.out.println(rs.getString(1));
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException("Connection failed: ", e);
+    }
+  }
+
+}

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/SimpleConnectionStringProviderAzureExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/SimpleConnectionStringProviderAzureExample.java
@@ -55,6 +55,8 @@ public class SimpleConnectionStringProviderAzureExample {
     try {
       OracleDataSource ds = new OracleDataSource();
       ds.setURL("jdbc:oracle:thin:@");
+      ds.setUser("DB_USERNAME");
+      ds.setPassword("DB_PASSWORD");
 
       Properties connectionProps = new Properties();
 


### PR DESCRIPTION
This PR adds a new Azure Key Vault **Connection String Provider** that allows Oracle JDBC to retrieve and parse **tnsnames.ora** files stored in **Azure Key Vault**. 
The provider supports selecting connection strings by specifying consumer groups such as **HIGH**, **MEDIUM**, **LOW**, **TRANSACTION_PROCESSING**, and **TRANSACTION_PROCESSING_URGENT**. This enables users to configure secure and workload-optimized connections based on predefined concurrency and resource levels.The implementation includes thorough testing for the new provider, ensuring functionality and reliability, along with an example demonstrating how users can set up and configure the new connection string provider.

The PR also refactors existing providers to use a centralized getSecret method, streamlining secret retrieval from Azure Key Vault. This improvement enhances code readability and maintainability, reducing duplicated code and simplifying secret access across different providers. 