### PR TITLE
Tinglwan upgrade ojdbc 23.6.0.24.10

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -17,12 +17,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-      # - name: Cache Maven packages
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ~/.m2
-      #     key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-      #     restore-keys: ${{ runner.os }}-m2
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
 
       - name: Install dependencies
         run: mvn install -DskipTests

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -17,12 +17,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+      # - name: Cache Maven packages
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ~/.m2
+      #     key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+      #     restore-keys: ${{ runner.os }}-m2
 
       - name: Install dependencies
         run: mvn install -DskipTests

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProvider.java
@@ -156,6 +156,15 @@ public class AzureAppConfigurationProvider
     return "azure";
   }
 
+  /**
+   * {@inheritDoc}
+   * @return cache of this provider which is used to store configuration
+   */
+  @Override
+  public OracleConfigurationCache getCache() {
+    return CACHE;
+  }
+
   private Properties getRemoteProperties(String location) {
     AzureAppConfigurationURLParser appConfig =
       new AzureAppConfigurationURLParser(location);
@@ -270,15 +279,6 @@ public class AzureAppConfigurationProvider
       } catch (AzureException e) {
         throw new OracleConfigurationProviderNetworkError(e);
       }
-  }
-
-  /**
-   * {@inheritDoc}
-   * @return cache of this provider which is used to store configuration
-   */
-  @Override
-  public OracleConfigurationCache getCache() {
-    return CACHE;
   }
 }
 

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProvider.java
@@ -91,7 +91,7 @@ public class AzureAppConfigurationProvider
    * in a frequency of 60 seconds if the remote location is unreachable.
     */
   private static final long MS_RETRY_INTERVAL = 60_000L;
-  private final OracleConfigurationCache cache = OracleConfigurationCache
+  private static final OracleConfigurationCache CACHE = OracleConfigurationCache
     .create(100);
 
   /**
@@ -113,7 +113,7 @@ public class AzureAppConfigurationProvider
   @Override
   public Properties getConnectionProperties(String location) {
     // If the location was already consulted, re-use the properties
-    Properties cachedProp = cache.get(location);
+    Properties cachedProp = CACHE.get(location);
     if (Objects.nonNull(cachedProp)) {
       return cachedProp;
     }
@@ -126,7 +126,7 @@ public class AzureAppConfigurationProvider
 
       properties.remove(CONFIG_TTL_JSON_OBJECT_NAME);
 
-      cache.put(
+      CACHE.put(
         location,
         properties,
         configTimeToLive,
@@ -134,7 +134,7 @@ public class AzureAppConfigurationProvider
         MS_REFRESH_TIMEOUT,
         MS_RETRY_INTERVAL);
     } else {
-      cache.put(location,
+      CACHE.put(location,
         properties,
         () -> this.refreshProperties(location),
         MS_REFRESH_TIMEOUT,
@@ -272,10 +272,13 @@ public class AzureAppConfigurationProvider
       }
   }
 
+  /**
+   * {@inheritDoc}
+   * @return cache of this provider which is used to store configuration
+   */
   @Override
-  public Properties removeProperties(String location) {
-    Properties deletedProp = cache.remove(location);
-    return deletedProp;
+  public OracleConfigurationCache getCache() {
+    return CACHE;
   }
 }
 

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureVaultJsonProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureVaultJsonProvider.java
@@ -43,6 +43,7 @@ import oracle.jdbc.provider.azure.keyvault.KeyVaultSecretFactory;
 import oracle.jdbc.provider.parameter.Parameter;
 import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.provider.parameter.ParameterSetParser;
+import oracle.jdbc.util.OracleConfigurationCache;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -89,7 +90,8 @@ public class AzureVaultJsonProvider extends OracleConfigurationJsonProvider {
     Map<String, String> optionsWithSecret = new HashMap<>(options);
     optionsWithSecret.put(valueFieldName, secretIdentifier);
 
-    ParameterSet parameters = PARAMETER_SET_PARSER.parseNamedValues(optionsWithSecret);
+    ParameterSet parameters = PARAMETER_SET_PARSER
+        .parseNamedValues(optionsWithSecret);
 
     String secretContent = KeyVaultSecretFactory.getInstance()
       .request(parameters)
@@ -112,5 +114,14 @@ public class AzureVaultJsonProvider extends OracleConfigurationJsonProvider {
   @Override
   public String getType() {
     return "azurevault";
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return cache of this provider which is used to store configuration
+   */
+  @Override
+  public OracleConfigurationCache getCache() {
+    return CACHE;
   }
 }

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderURLParserTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderURLParserTest.java
@@ -103,6 +103,7 @@ public class AzureAppConfigurationProviderURLParserTest {
     @Test
     void testValidUrlWithSecret() throws SQLException {
       String url = composeURL(options);
+      removeCacheEntry(url);
       verifyValidUrl(url);
     }
 
@@ -110,6 +111,7 @@ public class AzureAppConfigurationProviderURLParserTest {
     void testInvalidUrlWithSecret() {
       String invalidUrl = composeURL(options)
           .replace("@config-azure", "@config-azurex");
+      removeCacheEntry(invalidUrl);
       verifyInvalidTypeThrowsException(invalidUrl);
     }
 
@@ -117,6 +119,7 @@ public class AzureAppConfigurationProviderURLParserTest {
     void testInvalidKeyWithSecret() {
       ConfigurationClient client = getSecretCredentialClient();
       String url = composeURL(options);
+      removeCacheEntry(url);
       verifyInvalidKeyThrowsException(client, url);
     }
 
@@ -124,6 +127,7 @@ public class AzureAppConfigurationProviderURLParserTest {
     void testNonWhitelistedKeyWithSecret() {
       ConfigurationClient client = getSecretCredentialClient();
       String url = composeURL(options);
+      removeCacheEntry(url);
       verifyNonWhitelistedKeyThrowsException(client, url);
     }
   }
@@ -141,6 +145,7 @@ public class AzureAppConfigurationProviderURLParserTest {
             AzureTestProperty.AZURE_CLIENT_CERTIFICATE_PATH),
         "AZURE_TENANT_ID=" + TestProperties.getOrAbort(
             AzureTestProperty.AZURE_TENANT_ID));
+    removeCacheEntry(url);
     verifyValidUrl(url);
   }
 
@@ -159,6 +164,7 @@ public class AzureAppConfigurationProviderURLParserTest {
             AzureTestProperty.AZURE_CLIENT_PFX_PASSWORD),
         "AZURE_TENANT_ID=" + TestProperties.getOrAbort(
             AzureTestProperty.AZURE_TENANT_ID));
+    removeCacheEntry(url);
     verifyValidUrl(url);
   }
 

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpCloudStorageConfigurationProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpCloudStorageConfigurationProvider.java
@@ -45,12 +45,14 @@ import java.util.Map;
 import oracle.jdbc.driver.OracleConfigurationJsonProvider;
 import oracle.jdbc.provider.gcp.objectstorage.GcpCloudStorageFactory;
 import oracle.jdbc.provider.parameter.ParameterSet;
+import oracle.jdbc.util.OracleConfigurationCache;
 
 /**
  * A provider for JSON payload which contains configuration from GCP Cloud
  * Storage. See {@link #getJson(String)} for the spec of the JSON payload.
  */
-public class GcpCloudStorageConfigurationProvider extends OracleConfigurationJsonProvider {
+public class GcpCloudStorageConfigurationProvider
+    extends OracleConfigurationJsonProvider {
 
   public static final String PROJECT_PARAMETER = "project";
   public static final String BUCKET_PARAMETER = "bucket";
@@ -92,4 +94,12 @@ public class GcpCloudStorageConfigurationProvider extends OracleConfigurationJso
     return GcpCloudStorageFactory.getInstance().request(parameterSet).getContent();
   }
 
+  /**
+   * {@inheritDoc}
+   * @return cache of this provider which is used to store configuration
+   */
+  @Override
+  public OracleConfigurationCache getCache() {
+    return CACHE;
+  }
 }

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpSecretManagerConfigurationProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpSecretManagerConfigurationProvider.java
@@ -46,13 +46,15 @@ import java.util.Map;
 import oracle.jdbc.driver.OracleConfigurationJsonProvider;
 import oracle.jdbc.provider.gcp.secrets.GcpSecretManagerFactory;
 import oracle.jdbc.provider.parameter.ParameterSet;
+import oracle.jdbc.util.OracleConfigurationCache;
 
 /**
  * A provider for JSON payload which contains configuration from GCP Secret
  * Manager.
  * See {@link #getJson(String)} for the spec of the JSON payload.
  **/
-public class GcpSecretManagerConfigurationProvider extends OracleConfigurationJsonProvider {
+public class GcpSecretManagerConfigurationProvider
+    extends OracleConfigurationJsonProvider {
 
   @Override
   public String getType() {
@@ -78,4 +80,12 @@ public class GcpSecretManagerConfigurationProvider extends OracleConfigurationJs
         GcpSecretManagerFactory.getInstance().request(parameterSet).getContent().getData().toByteArray());
   }
 
+  /**
+   * {@inheritDoc}
+   * @return cache of this provider which is used to store configuration
+   */
+  @Override
+  public OracleConfigurationCache getCache() {
+    return CACHE;
+  }
 }

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
@@ -52,7 +52,7 @@ public class OciDatabaseToolsConnectionProvider
    */
   private static final long MS_RETRY_INTERVAL = 60_000L;
 
-  private static final OracleConfigurationCache cache = OracleConfigurationCache
+  private static final OracleConfigurationCache CACHE = OracleConfigurationCache
     .create(100);
 
   private ParameterSet commonParameters;
@@ -61,7 +61,7 @@ public class OciDatabaseToolsConnectionProvider
   public Properties getConnectionProperties(String location)
       throws SQLException {
 
-    Properties cachedProp = cache.get(location);
+    Properties cachedProp = CACHE.get(location);
     if (Objects.nonNull(cachedProp)) {
       return cachedProp;
     }
@@ -75,7 +75,7 @@ public class OciDatabaseToolsConnectionProvider
 
       // properties stored in the cache should not contain information of TTL
       properties.remove(CONFIG_TIME_TO_LIVE);
-      cache.put(
+      CACHE.put(
         location,
         properties,
         configTimeToLive,
@@ -83,7 +83,7 @@ public class OciDatabaseToolsConnectionProvider
         MS_REFRESH_TIMEOUT,
         MS_RETRY_INTERVAL);
     } else {
-      cache.put(location,
+      CACHE.put(location,
         properties,
         () -> this.refreshProperties(location),
         MS_REFRESH_TIMEOUT,
@@ -305,12 +305,6 @@ public class OciDatabaseToolsConnectionProvider
       .getContent();
   }
 
-  @Override
-  public Properties removeProperties(String location) {
-    Properties deletedProp = cache.remove(location);
-    return deletedProp;
-  }
-
   private Properties refreshProperties(String location)
     throws OracleConfigurationProviderNetworkError {
     try {
@@ -318,6 +312,15 @@ public class OciDatabaseToolsConnectionProvider
     } catch (BmcException bmcException) {
       throw new OracleConfigurationProviderNetworkError(bmcException);
     }
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return cache of this provider which is used to store configuration
+   */
+  @Override
+  public OracleConfigurationCache getCache() {
+    return CACHE;
   }
 }
 

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
@@ -98,6 +98,15 @@ public class OciDatabaseToolsConnectionProvider
     return "ocidbtools";
   }
 
+  /**
+   * {@inheritDoc}
+   * @return cache of this provider which is used to store configuration
+   */
+  @Override
+  public OracleConfigurationCache getCache() {
+    return CACHE;
+  }
+
   private Properties getRemoteProperties(String location) {
     // Split connection ocid from options
     Map<String, String> options = null;
@@ -312,15 +321,6 @@ public class OciDatabaseToolsConnectionProvider
     } catch (BmcException bmcException) {
       throw new OracleConfigurationProviderNetworkError(bmcException);
     }
-  }
-
-  /**
-   * {@inheritDoc}
-   * @return cache of this provider which is used to store configuration
-   */
-  @Override
-  public OracleConfigurationCache getCache() {
-    return CACHE;
   }
 }
 

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciObjectStorageProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciObjectStorageProvider.java
@@ -41,8 +41,9 @@ package oracle.jdbc.provider.oci.configuration;
 import oracle.jdbc.driver.OracleConfigurationJsonProvider;
 import oracle.jdbc.provider.oci.objectstorage.ObjectFactory;
 import oracle.jdbc.provider.parameter.ParameterSet;
+import oracle.jdbc.util.OracleConfigurationCache;
 
-import java.io.*;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -98,5 +99,14 @@ public class OciObjectStorageProvider
   @Override
   public String getType() {
     return "ociobject";
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return cache of this provider which is used to store configuration
+   */
+  @Override
+  public OracleConfigurationCache getCache() {
+    return CACHE;
   }
 }

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciVaultJsonProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciVaultJsonProvider.java
@@ -3,10 +3,10 @@ package oracle.jdbc.provider.oci.configuration;
 import oracle.jdbc.driver.OracleConfigurationJsonProvider;
 import oracle.jdbc.provider.oci.vault.SecretFactory;
 import oracle.jdbc.provider.parameter.ParameterSet;
+import oracle.jdbc.util.OracleConfigurationCache;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.sql.SQLException;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +44,8 @@ public class OciVaultJsonProvider extends OracleConfigurationJsonProvider {
       .getContent()
       .getBase64Secret();
 
-    InputStream inputStream = new ByteArrayInputStream(Base64.getDecoder().decode(secretContent));
+    InputStream inputStream = new ByteArrayInputStream(
+        Base64.getDecoder().decode(secretContent));
     return inputStream;
   }
 
@@ -58,5 +59,14 @@ public class OciVaultJsonProvider extends OracleConfigurationJsonProvider {
   @Override
   public String getType() {
     return "ocivault";
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return cache of this provider which is used to store configuration
+   */
+  @Override
+  public OracleConfigurationCache getCache() {
+    return CACHE;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <jdbc.version>23.4.0.24.05</jdbc.version>
+    <jdbc.version>23.6.0.24.10</jdbc.version>
     <junit.version>5.9.0</junit.version>
     <mockito.version>4.11.0</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
- Upgraded the version of ojdbc8 to 23.6.0.24.10.
- Changed the type of OracleConfigurationCache in AzureAppConfigurationProvider to private static final so that the providers created in different threads can access the same cache. The same has already be done in the other providers, I'm not sure why we missed this one.
- Updated AzureAppConfigurationProviderURLParserTest to ensure that the configuration is removed from the cache when each tests begins. 