### PR TITLE
Refactor Azure and GCP getSecret Methods to Use Common getResource Logic

### DIFF
--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultSecretProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultSecretProvider.java
@@ -72,27 +72,25 @@ class KeyVaultSecretProvider extends AzureResourceProvider {
 
   /**
    * <p>
-   * Returns a secret identified by a parameter named "vaultUrl" which
-   * configures {@link KeyVaultSecretFactory#VAULT_URL}, and "secretName" which
-   * configure {@link KeyVaultSecretFactory#SECRET_NAME}. This method parses
-   * these parameters from text values.
+   * Retrieves a secret from Azure Key Vault based on parameters provided
+   * in {@code parameterValues}. This method centralizes secret retrieval
+   * logic and can be used by subclasses implementing
+   * the {@link oracle.jdbc.spi.OracleResourceProvider} SPI.
    * </p><p>
-   * This method is designed to be called from subclasses which implement an
-   * {@link oracle.jdbc.spi.OracleResourceProvider} SPI.
+   * The method uses the {@code getResource} method to parse the
+   * {@code parameterValues} and request the secret from Azure Key Vault via
+   * the {@link KeyVaultSecretFactory} instance.
+   * The secret value is returned as a {@code String}.
    * </p>
    *
-   * @param parameterValues Text values of parameters. Not null.
-   * @return The identified secret. Not null.
+   * @param parameterValues A map of parameter names and their corresponding
+   * values required for secret retrieval. Must not be null.
+   * @return The secret value as a {@code String}. Not null.
    */
   protected final String getSecret(
-    Map<Parameter, CharSequence> parameterValues) {
-
-    ParameterSet parameterSet = parseParameterValues(parameterValues);
-
-    return KeyVaultSecretFactory.getInstance()
-      .request(parameterSet)
-      .getContent()
-      .getValue();
+          Map<Parameter, CharSequence> parameterValues) {
+    return getResource(KeyVaultSecretFactory.getInstance(), parameterValues)
+            .getValue();
   }
 
 }

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultSecretProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultSecretProvider.java
@@ -88,7 +88,7 @@ class KeyVaultSecretProvider extends AzureResourceProvider {
    * @return The secret value as a {@code String}. Not null.
    */
   protected final String getSecret(
-          Map<Parameter, CharSequence> parameterValues) {
+    Map<Parameter, CharSequence> parameterValues) {
     return getResource(KeyVaultSecretFactory.getInstance(), parameterValues)
             .getValue();
   }

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpSecretManagerProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpSecretManagerProvider.java
@@ -67,9 +67,14 @@ class GcpSecretManagerProvider extends AbstractResourceProvider {
 
   /**
    * <p>
-   * Returns a secret identified by a parameter named "secretVersionName" which
-   * configures {@link GcpSecretManagerFactory#SECRET_VERSION_NAME}. This method
-   * parses these parameters from text values.
+   * Retrieves a secret from GCP Secret Manager based on parameters provided
+   * in {@code parameterValues}. This method centralizes secret retrieval logic
+   * </p>
+   * <p>
+   * The method uses the {@code getResource} method to parse the
+   * {@code parameterValues} and request the secret from GCP Secret Manager
+   * via the {@link GcpSecretManagerFactory} instance.
+   * The secret is returned as a {@code ByteString}.
    * </p>
    * <p>
    * This method is designed to be called from subclasses which implement an
@@ -82,12 +87,8 @@ class GcpSecretManagerProvider extends AbstractResourceProvider {
   protected final ByteString getSecret(
       Map<Parameter, CharSequence> parameterValues) {
 
-    ParameterSet parameterSet = parseParameterValues(parameterValues);
-
-    return GcpSecretManagerFactory.getInstance()
-        .request(parameterSet)
-        .getContent()
-        .getData();
+    return getResource(GcpSecretManagerFactory.getInstance(), parameterValues)
+            .getData();
   }
 
 }


### PR DESCRIPTION
This PR refactors the `getSecret` methods in **Azure** and **GCP** providers to use the `getResource` method from the common module, aligning with the approach implemented for **OCI** providers. By centralizing parameter parsing and resource retrieval logic, these changes reduce code duplication, enhance maintainability, and ensure consistent behavior across providers.
JavaDocs have been updated to reflect these improvements


