### PR TITLE
Rename tns-alias to tnsAlias in Azure Provider for Consistency

### DIFF
--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -518,7 +518,7 @@ This provider retrieves and decodes a `tnsnames.ora` file stored as a base64-enc
 
 This enables flexible configuration for secure database connections using the alias names defined in your `tnsnames.ora` file.
 
-In addition to the set of [common parameters](#common-parameters-for-resource-providers), this provider also supports the parameters listed below.
+In addition to the set of [common parameters](#common-parameters-for-resource-providers), this provider also requires the parameters listed below.
 
 <table>
 <thead>

--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -543,7 +543,7 @@ In addition to the set of [common parameters](#common-parameters-for-resource-pr
     <td><i>No default value. A value must be configured for this parameter.</i></td>
   </tr>
   <tr>
-    <td><code>tns-alias</code></td>
+    <td><code>tnsAlias</code></td>
     <td>Specifies the alias to retrieve the appropriate connection string from the <code>tnsnames.ora</code> file.</td> 
     <td>Any valid alias present in your <code>tnsnames.ora</code> file.</td>
     <td><i>No default value. A value must be configured for this parameter.</i></td> 

--- a/ojdbc-provider-azure/example-key-vault.properties
+++ b/ojdbc-provider-azure/example-key-vault.properties
@@ -63,6 +63,6 @@ oracle.jdbc.provider.password.secretName=${PASSWORD_SECRET_NAME}
 oracle.jdbc.provider.connectionString=ojdbc-provider-azure-key-vault-tnsnames
 oracle.jdbc.provider.connectionString.vaultUrl=${KEY_VAULT_URL}
 oracle.jdbc.provider.connectionString.secretName=${TNSNAMES_SECRET_NAME}
-oracle.jdbc.provider.connectionString.tns-alias=${TNS_ALIAS}
+oracle.jdbc.provider.connectionString.tnsAlias=${TNS_ALIAS}
 
 

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultConnectionStringProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultConnectionStringProvider.java
@@ -102,6 +102,15 @@ public class KeyVaultConnectionStringProvider
   @Override
   public String getConnectionString(Map<Parameter, CharSequence> parameterValues) {
 
+    String alias;
+    try {
+      alias = parseParameterValues(parameterValues).getRequired(TNS_ALIAS);
+    } catch (IllegalStateException e) {
+      throw new IllegalArgumentException(
+              "Required parameter 'tnsAlias' is missing", e
+      );
+    }
+
     // Retrieve the secret containing tnsnames.ora content from Azure Key Vault
     String secretValue = getSecret(parameterValues);
 
@@ -113,15 +122,6 @@ public class KeyVaultConnectionStringProvider
       tnsNames = TNSNames.read(inputStream);
     } catch (IOException e) {
       throw new IllegalStateException("Failed to read tnsnames.ora content", e);
-    }
-
-    String alias;
-    try {
-      alias = parseParameterValues(parameterValues).getRequired(TNS_ALIAS);
-    } catch (IllegalStateException e) {
-      throw new IllegalArgumentException(
-              "Required parameter 'tnsAlias' is missing", e
-      );
     }
 
     String connectionString = tnsNames.getConnectionStringByAlias(alias);

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultConnectionStringProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/KeyVaultConnectionStringProvider.java
@@ -55,7 +55,8 @@ import static oracle.jdbc.provider.util.CommonParameters.TNS_ALIAS;
  * A provider for securely retrieving the connection string from a tnsnames.ora
  * file stored in Azure Key Vault for use with an Oracle Autonomous Database.
  * The tnsnames.ora file is stored as a base64-encoded secret in Azure Key Vault,
- * and is decoded and parsed to select connection strings based on specified aliases.
+ * and is decoded and parsed to select connection strings based on specified
+ * aliases.
  * </p>
  * <p>
  * This class implements the {@link ConnectionStringProvider} SPI defined by
@@ -68,7 +69,7 @@ public class KeyVaultConnectionStringProvider
         implements ConnectionStringProvider {
 
   private static final ResourceParameter[] TNS_NAMES_PARAMETERS = {
-          new ResourceParameter("tns-alias", TNS_ALIAS)
+          new ResourceParameter("tnsAlias", TNS_ALIAS)
   };
 
   /**
@@ -90,7 +91,7 @@ public class KeyVaultConnectionStringProvider
    *
    * @param parameterValues The parameters required to access the tnsnames.ora
    * file in Azure Key Vault, including the vault URL, the secret name, and
-   * the tns-alias.
+   * the tnsAlias.
    * @return The connection string associated with the specified alias
    * in the tnsnames.ora file.
    * @throws IllegalStateException If there is an error reading the tnsnames.ora
@@ -119,7 +120,7 @@ public class KeyVaultConnectionStringProvider
       alias = parseParameterValues(parameterValues).getRequired(TNS_ALIAS);
     } catch (IllegalStateException e) {
       throw new IllegalArgumentException(
-              "Required parameter 'tns-alias' is missing", e
+              "Required parameter 'tnsAlias' is missing", e
       );
     }
 

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultConnectionStringProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/KeyVaultConnectionStringProviderTest.java
@@ -91,7 +91,7 @@ public class KeyVaultConnectionStringProviderTest {
 
     Parameter aliasParameter =
       parameters.stream()
-        .filter(parameter -> "tns-alias".equals(parameter.name()))
+        .filter(parameter -> "tnsAlias".equals(parameter.name()))
         .findFirst()
         .orElseThrow(AssertionError::new);
     assertTrue(aliasParameter.isSensitive());
@@ -108,7 +108,7 @@ public class KeyVaultConnectionStringProviderTest {
     testParameters.put("secretName",
       TestProperties.getOrAbort(AzureTestProperty.AZURE_TNS_NAMES_SECRET_NAME));
 
-    testParameters.put("tns-alias",
+    testParameters.put("tnsAlias",
       TestProperties.getOrAbort(AzureTestProperty.AZURE_TNS_ALIAS_SECRET_NAME));
 
     AzureResourceProviderTestUtil.configureAuthentication(testParameters);
@@ -128,7 +128,7 @@ public class KeyVaultConnectionStringProviderTest {
     testParameters.put("secretName",
       TestProperties.getOrAbort(AzureTestProperty.AZURE_TNS_NAMES_SECRET_NAME));
 
-    testParameters.put("tns-alias", "INVALID_ALIAS");
+    testParameters.put("tnsAlias", "INVALID_ALIAS");
 
     AzureResourceProviderTestUtil.configureAuthentication(testParameters);
     Map<Parameter, CharSequence> parameterValues =
@@ -155,7 +155,7 @@ public class KeyVaultConnectionStringProviderTest {
 
     assertThrows(IllegalArgumentException.class,
             () -> PROVIDER.getConnectionString(parameterValues),
-            "Expected IllegalArgumentException when tns-alias parameter is missing"
+            "Expected IllegalArgumentException when tnsAlias parameter is missing"
     );
   }
 
@@ -167,7 +167,7 @@ public class KeyVaultConnectionStringProviderTest {
 
     testParameters.put("secretName",
             TestProperties.getOrAbort(AzureTestProperty.AZURE_NON_BASE64_TNS_NAMES_SECRET_NAME));
-    testParameters.put("tns-alias",
+    testParameters.put("tnsAlias",
             TestProperties.getOrAbort(AzureTestProperty.AZURE_TNS_NAMES_SECRET_NAME));
 
     AzureResourceProviderTestUtil.configureAuthentication(testParameters);

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/SimpleConnectionStringProviderAzureExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/SimpleConnectionStringProviderAzureExample.java
@@ -71,7 +71,7 @@ public class SimpleConnectionStringProviderAzureExample {
         "your-tnsnames-secret-name");
 
       // Specify the tns-alias to retrieve the corresponding connection string
-      connectionProps.put("oracle.jdbc.provider.connectionString.tns-alias",
+      connectionProps.put("oracle.jdbc.provider.connectionString.tnsAlias",
         "YOUR_TNS_ALIAS");
 
       // TLS Configuration for secure connection


### PR DESCRIPTION
This PR updates the **Azure** provider by renaming the `tns-alias` parameter to` tnsAlias` to ensure consistency with other parameters. Changes include updates to the provider code, tests, and documentation to reflect the new name. Sample tests and the README have also been updated to provide clear information for users. These changes improve parameter naming consistency and simplify usage.