### PR TITLE
Implement Wallet Expiration Parsing and Resource Caching Enhancement

### DIFF
--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
@@ -45,7 +45,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.security.KeyStore;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
@@ -230,7 +229,6 @@ public final class Wallet {
             break;
           case README_FILE:
             readmeContent = readStreamToString(zipStream);
-            System.out.println(readmeContent);
             break;
           default:
             // Ignore other files
@@ -300,20 +298,17 @@ public final class Wallet {
     if (matcher.find()) {
       String expiryDateString = matcher.group(1).trim();
       expiryDateString = expiryDateString.replace(" UTC", "Z");
-      System.out.println("expiryDateString: " + expiryDateString);
+
+      try {
       DateTimeFormatter formatter = new DateTimeFormatterBuilder()
               .appendPattern("yyyy-MM-dd HH:mm:ss")
               .optionalStart()
               .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
               .optionalEnd()
               .appendPattern("X") // Accept 'Z' as offset
-              .toFormatter(Locale.ENGLISH); // Specify locale explicitly
-      System.out.println("formatter: " + formatter);
+              .toFormatter(Locale.ENGLISH);
 
-      try {
-        OffsetDateTime expirationDate = OffsetDateTime.parse(expiryDateString, formatter);
-        System.out.println("Parsed Expiration Date: " + expirationDate);
-        return expirationDate;
+        return OffsetDateTime.parse(expiryDateString, formatter);
       } catch (DateTimeParseException e) {
         throw new IllegalStateException("Failed to parse expiration date from README", e);
       }

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
@@ -308,8 +308,12 @@ public final class Wallet {
               .toFormatter()
               .withZone(ZoneOffset.UTC);
       System.out.println("formatter: " + formatter);
+
       try {
-        return OffsetDateTime.parse(expiryDateString, formatter);
+           OffsetDateTime res = OffsetDateTime.parse(expiryDateString,
+                formatter);
+        System.out.println("res: " + res);
+        return res;
       } catch (DateTimeParseException e) {
         throw new IllegalStateException("Failed to parse expiration date from README", e);
       }

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
@@ -300,7 +300,7 @@ public final class Wallet {
       DateTimeFormatter formatter = new DateTimeFormatterBuilder()
               .appendPattern("yyyy-MM-dd HH:mm:ss")
               .optionalStart()
-              .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
+              .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
               .optionalEnd()
               .appendLiteral(" UTC")
               .toFormatter()

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
@@ -43,7 +43,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -312,7 +311,6 @@ public final class Wallet {
         throw new IllegalStateException("Failed to parse expiration date from README", e);
       }
     } else {
-      // If the pattern is not found, return null or handle accordingly
       return null;
     }
   }

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
@@ -229,6 +229,7 @@ public final class Wallet {
             break;
           case README_FILE:
             readmeContent = readStreamToString(zipStream);
+            System.out.println(readmeContent);
             break;
           default:
             // Ignore other files

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
@@ -50,6 +50,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
@@ -298,22 +299,21 @@ public final class Wallet {
     Matcher matcher = EXPIRY_PATTERN.matcher(readmeContent);
     if (matcher.find()) {
       String expiryDateString = matcher.group(1).trim();
+      expiryDateString = expiryDateString.replace(" UTC", "Z");
       System.out.println("expiryDateString: " + expiryDateString);
       DateTimeFormatter formatter = new DateTimeFormatterBuilder()
               .appendPattern("yyyy-MM-dd HH:mm:ss")
               .optionalStart()
               .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
               .optionalEnd()
-              .appendLiteral(" UTC")
-              .toFormatter()
-              .withZone(ZoneOffset.UTC);
+              .appendPattern("X") // Accept 'Z' as offset
+              .toFormatter(Locale.ENGLISH); // Specify locale explicitly
       System.out.println("formatter: " + formatter);
 
       try {
-           OffsetDateTime res = OffsetDateTime.parse(expiryDateString,
-                formatter);
-        System.out.println("res: " + res);
-        return res;
+        OffsetDateTime expirationDate = OffsetDateTime.parse(expiryDateString, formatter);
+        System.out.println("Parsed Expiration Date: " + expirationDate);
+        return expirationDate;
       } catch (DateTimeParseException e) {
         throw new IllegalStateException("Failed to parse expiration date from README", e);
       }

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/Wallet.java
@@ -298,6 +298,7 @@ public final class Wallet {
     Matcher matcher = EXPIRY_PATTERN.matcher(readmeContent);
     if (matcher.find()) {
       String expiryDateString = matcher.group(1).trim();
+      System.out.println("expiryDateString: " + expiryDateString);
       DateTimeFormatter formatter = new DateTimeFormatterBuilder()
               .appendPattern("yyyy-MM-dd HH:mm:ss")
               .optionalStart()
@@ -306,6 +307,7 @@ public final class Wallet {
               .appendLiteral(" UTC")
               .toFormatter()
               .withZone(ZoneOffset.UTC);
+      System.out.println("formatter: " + formatter);
       try {
         return OffsetDateTime.parse(expiryDateString, formatter);
       } catch (DateTimeParseException e) {

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/database/WalletFactory.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/database/WalletFactory.java
@@ -132,7 +132,6 @@ public final class WalletFactory extends OciResourceFactory<Wallet> {
       }
 
       OffsetDateTime expiry = wallet.getExpirationDate();
-      System.out.println(expiry);
       if (expiry == null) {
         // If expiry could not be determined, treat as permanent
         return Resource.createPermanentResource(wallet, false);

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/database/WalletFactory.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/database/WalletFactory.java
@@ -76,8 +76,6 @@ public final class WalletFactory extends OciResourceFactory<Wallet> {
 
   /**
    * A cache of wallet configurations requested from the OCI database service.
-   * TODO: The cache should invalidate entries after TLS certificates have
-   *   expired.
    */
   private static final ResourceFactory<Wallet> INSTANCE =
     CachedResourceFactory.create(new WalletFactory());
@@ -141,10 +139,6 @@ public final class WalletFactory extends OciResourceFactory<Wallet> {
       } else {
         return Resource.createExpiringResource(wallet, expiry, false);
       }
-
-      // TODO: It may be possible to parse an expiration time from the wallet
-      //  README, and return an expiring resource here.
-      //return Resource.createPermanentResource(wallet, false);
     }
     finally {
       Arrays.fill(password, (char)0);

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/database/WalletFactory.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/database/WalletFactory.java
@@ -53,6 +53,7 @@ import oracle.jdbc.provider.util.Wallet;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.zip.ZipInputStream;
 
@@ -132,9 +133,18 @@ public final class WalletFactory extends OciResourceFactory<Wallet> {
           "Failed to close ZIP stream", ioException);
       }
 
+      OffsetDateTime expiry = wallet.getExpirationDate();
+      System.out.println(expiry);
+      if (expiry == null) {
+        // If expiry could not be determined, treat as permanent
+        return Resource.createPermanentResource(wallet, false);
+      } else {
+        return Resource.createExpiringResource(wallet, expiry, false);
+      }
+
       // TODO: It may be possible to parse an expiration time from the wallet
       //  README, and return an expiring resource here.
-      return Resource.createPermanentResource(wallet, false);
+      //return Resource.createPermanentResource(wallet, false);
     }
     finally {
       Arrays.fill(password, (char)0);


### PR DESCRIPTION
This pull request implements the parsing of the wallet's expiration date from the README file within the wallet ZIP archive, addressing the existing TODO. By enhancing the Wallet class to extract the expiration date and updating the WalletFactory to create expiring resources based on this date, we ensure that the caching mechanism automatically invalidates expired wallets. This change improves security by preventing the use of expired certificates and enhances reliability by ensuring secure connections to the Autonomous Database.