### PR TITLE
Update Open Telemetry dependency version

### DIFF
--- a/ojdbc-provider-azure/pom.xml
+++ b/ojdbc-provider-azure/pom.xml
@@ -18,7 +18,7 @@
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-sdk-bom</artifactId>
-        <version>1.2.27</version>
+        <version>1.2.19</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/ojdbc-provider-oci/pom.xml
+++ b/ojdbc-provider-oci/pom.xml
@@ -18,7 +18,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>3.49.0</version>
+        <version>3.48.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/ojdbc-provider-opentelemetry/pom.xml
+++ b/ojdbc-provider-opentelemetry/pom.xml
@@ -15,7 +15,7 @@
     </parent>
 
     <properties>
-        <opentelemetry.version>1.42.1</opentelemetry.version>
+        <opentelemetry.version>1.29.0</opentelemetry.version>
     </properties>
 
     <dependencies>

--- a/ojdbc-provider-opentelemetry/pom.xml
+++ b/ojdbc-provider-opentelemetry/pom.xml
@@ -15,7 +15,7 @@
     </parent>
 
     <properties>
-        <opentelemetry.version>1.29.0</opentelemetry.version>
+        <opentelemetry.version>1.44.1</opentelemetry.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Updated io.opentelemetry:opentelemetry-api to version 1.44.1.