### PR TITLE
Correcting redirectUri parameter name

### DIFF
--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -694,7 +694,7 @@ common set of parameters.
       </i></td>
     </tr>
     <tr>
-      <td>redirectUrl</td>
+      <td>redirectUri</td>
       <td>
       <a href="https://docs.microsoft.com/en-us/azure/active-directory/develop/reply-url">
       Redirect URL


### PR DESCRIPTION
The README listed `redirectUrl` [but the code recognizes `redirectUri`](https://github.com/oracle/ojdbc-extensions/blob/f86022d0896891561fcba7bc7f1c43d89bc86556/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/resource/AzureResourceProvider.java#L67).