### PR TITLE
Update README files to reflect version 1.0.2

### DIFF
--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -44,7 +44,7 @@ JDK versions. The coordinates for the latest release are:
 <dependency>
   <groupId>com.oracle.database.jdbc</groupId>
   <artifactId>ojdbc-provider-azure</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
 </dependency>
 ```
 

--- a/ojdbc-provider-oci/README.md
+++ b/ojdbc-provider-oci/README.md
@@ -56,7 +56,7 @@ JDK versions. The coordinates for the latest release are:
 <dependency>
   <groupId>com.oracle.database.jdbc</groupId>
   <artifactId>ojdbc-provider-oci</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
 </dependency>
 ```
 

--- a/ojdbc-provider-opentelemetry/README.md
+++ b/ojdbc-provider-opentelemetry/README.md
@@ -44,7 +44,7 @@ The coordinates for the latest release are:
 <dependency>
   <groupId>com.oracle.database.jdbc</groupId>
   <artifactId>ojdbc-provider-opentelemetry</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
 </dependency>
 ```
 


### PR DESCRIPTION
This PR updates the README files for the OCI, Azure, and OpenTelemetry providers to reflect the latest version `1.0.2`.