### PR TITLE
Fix "Provider: azure not enabled through: oracle.jdbc.configurationProviders" error

### DIFF
--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderURLParserTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderURLParserTest.java
@@ -230,7 +230,7 @@ public class AzureAppConfigurationProviderURLParserTest {
           OracleDataSource ds = new OracleDataSource();
           ds.setURL(url);
           Connection cn = ds.getConnection();
-          ResultSet rs = cn.createStatement().executeQuery("SELECT 'Hello, db' FROM sys.dual");
+          ResultSet rs = cn.createStatement().executeQuery("SELECT 'Hello, db1' FROM sys.dual");
           if (rs.next())
             System.out.println(rs.getString(1));
           },

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderURLParserTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderURLParserTest.java
@@ -230,7 +230,7 @@ public class AzureAppConfigurationProviderURLParserTest {
           OracleDataSource ds = new OracleDataSource();
           ds.setURL(url);
           Connection cn = ds.getConnection();
-          ResultSet rs = cn.createStatement().executeQuery("SELECT 'Hello, db1' FROM sys.dual");
+          ResultSet rs = cn.createStatement().executeQuery("SELECT 'Hello, db' FROM sys.dual");
           if (rs.next())
             System.out.println(rs.getString(1));
           },

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderURLParserTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderURLParserTest.java
@@ -229,7 +229,11 @@ public class AzureAppConfigurationProviderURLParserTest {
         () -> {
           OracleDataSource ds = new OracleDataSource();
           ds.setURL(url);
-          ds.getConnection();},
+          Connection cn = ds.getConnection();
+          ResultSet rs = cn.createStatement().executeQuery("SELECT 'Hello, db' FROM sys.dual");
+          if (rs.next())
+            System.out.println(rs.getString(1));
+          },
         "Should throw an SQLException");
       // Expected exception:
       // ORA-18729: Property is not whitelisted for external providers

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderURLParserTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderURLParserTest.java
@@ -40,6 +40,7 @@ package oracle.jdbc.provider.azure.configuration;
 
 import com.azure.data.appconfiguration.ConfigurationClient;
 import com.azure.data.appconfiguration.ConfigurationClientBuilder;
+import com.azure.data.appconfiguration.models.ConfigurationSetting;
 import com.azure.identity.ClientSecretCredentialBuilder;
 import oracle.jdbc.provider.TestProperties;
 import oracle.jdbc.provider.azure.authentication.AzureAuthenticationMethod;
@@ -117,6 +118,13 @@ public class AzureAppConfigurationProviderURLParserTest {
       ConfigurationClient client = getSecretCredentialClient();
       String url = composeURL(options);
       removeCacheEntry(url);
+      System.out.println("Print cached properties");
+      Properties cached;
+      if ((cached = CACHE.get(url.replaceFirst("jdbc:oracle:thin:@config-azure://", ""))) != null) {
+        cached.forEach((k, v) -> {
+          System.out.println("key: " + k + ", value: " + v);
+        });
+      }
       verifyInvalidKeyThrowsException(client, url);
     }
 
@@ -213,7 +221,8 @@ public class AzureAppConfigurationProviderURLParserTest {
     String value = "foo";
 
     // Add the new configuration setting
-    client.addConfigurationSetting(key, label, value);
+    ConfigurationSetting setting = client.addConfigurationSetting(key, label, value);
+    System.out.println("Added: " + setting.getKey() + ", " + setting.getValue());
 
     try {
       SQLException exception = assertThrows(SQLException.class,

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderURLParserTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderURLParserTest.java
@@ -72,6 +72,7 @@ public class AzureAppConfigurationProviderURLParserTest {
   private static OracleConfigurationCache CACHE;
   @BeforeAll
   static void init() {
+    OracleConfigurationProvider.allowedProviders.add("azure");
     CACHE = ((AzureAppConfigurationProvider)OracleConfigurationProvider
         .find("azure"))
         .getCache();
@@ -95,10 +96,6 @@ public class AzureAppConfigurationProviderURLParserTest {
           AzureTestProperty.AZURE_CLIENT_SECRET),
         "AZURE_TENANT_ID=" + TestProperties.getOrAbort(
           AzureTestProperty.AZURE_TENANT_ID)};
-
-      AzureAppConfigurationProvider provider =
-          (AzureAppConfigurationProvider)OracleConfigurationProvider
-              .find("azure");
     }
     @Test
     void testValidUrlWithSecret() throws SQLException {

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureVaultSecretProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureVaultSecretProviderTest.java
@@ -41,6 +41,7 @@ import oracle.jdbc.provider.TestProperties;
 import oracle.jdbc.provider.azure.authentication.AzureAuthenticationMethod;
 import oracle.jdbc.provider.azure.AzureTestProperty;
 import oracle.jdbc.spi.OracleConfigurationJsonSecretProvider;
+import oracle.jdbc.spi.OracleConfigurationProvider;
 import oracle.jdbc.spi.OracleConfigurationSecretProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -49,6 +50,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class AzureVaultSecretProviderTest {
+  static {
+    OracleConfigurationProvider.allowedProviders.add("azurevault");
+  }
+
   private static final OracleConfigurationSecretProvider PROVIDER =
     OracleConfigurationSecretProvider.find("azurevault");
 


### PR DESCRIPTION
In some of the Azure tests `OracleConfigurationProvider.find()` are called outside of the driver code, and the provider is not yet added to the list of the allowed configuration provider at this point. Hence we need to add those providers manually in the test codes. 