### PR TITLE
Centralize Base64 decoding in AWS and GCP providers

### DIFF
--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/SecretsManagerConnectionStringProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/SecretsManagerConnectionStringProvider.java
@@ -49,6 +49,7 @@ import java.util.Base64;
 import java.util.Map;
 
 import static oracle.jdbc.provider.util.CommonParameters.TNS_ALIAS;
+import static oracle.jdbc.provider.util.FileUtils.decodeIfBase64;
 import static oracle.jdbc.provider.util.FileUtils.isBase64Encoded;
 
 /**
@@ -103,10 +104,7 @@ public class SecretsManagerConnectionStringProvider
   @Override
   public String getConnectionString(Map<Parameter, CharSequence> parameterValues) {
     String alias = parseParameterValues(parameterValues).getRequired(TNS_ALIAS);
-    byte[] secretBytes = getSecret(parameterValues).getBytes();
-
-    byte[] fileBytes = isBase64Encoded(secretBytes)
-      ? Base64.getDecoder().decode(secretBytes) : secretBytes;
+    byte[] fileBytes = decodeIfBase64(getSecret(parameterValues).getBytes());
 
     try (InputStream inputStream = new ByteArrayInputStream(fileBytes)) {
       TNSNames tnsNames = TNSNames.read(inputStream);

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpSecretManagerConnectionStringProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpSecretManagerConnectionStringProvider.java
@@ -39,17 +39,16 @@
 package oracle.jdbc.provider.gcp.resource;
 
 import oracle.jdbc.provider.resource.ResourceParameter;
-import oracle.jdbc.provider.util.FileUtils;
 import oracle.jdbc.provider.util.TNSNames;
 import oracle.jdbc.spi.ConnectionStringProvider;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Base64;
 import java.util.Map;
 
 import static oracle.jdbc.provider.util.CommonParameters.TNS_ALIAS;
+import static oracle.jdbc.provider.util.FileUtils.decodeIfBase64;
 
 
 /**
@@ -103,12 +102,7 @@ public class GcpSecretManagerConnectionStringProvider
    */
   @Override
   public String getConnectionString(Map<Parameter, CharSequence> parameterValues) {
-
-    byte[] fileBytes = getSecret(parameterValues).toByteArray();
-
-    if (FileUtils.isBase64Encoded(fileBytes)) {
-      fileBytes = Base64.getDecoder().decode(fileBytes);
-    }
+    byte[] fileBytes = decodeIfBase64(getSecret(parameterValues).toByteArray());
 
     TNSNames tnsNames;
     try (InputStream inputStream = new ByteArrayInputStream(fileBytes)) {

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpSecretManagerSEPSProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpSecretManagerSEPSProvider.java
@@ -40,16 +40,15 @@ package oracle.jdbc.provider.gcp.resource;
 
 import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.provider.resource.ResourceParameter;
-import oracle.jdbc.provider.util.FileUtils;
 import oracle.jdbc.provider.util.WalletUtils;
 import oracle.jdbc.spi.PasswordProvider;
 import oracle.jdbc.spi.UsernameProvider;
 
-import java.util.Base64;
 import java.util.Map;
 
 import static oracle.jdbc.provider.util.CommonParameters.CONNECTION_STRING_INDEX;
 import static oracle.jdbc.provider.util.CommonParameters.PASSWORD;
+import static oracle.jdbc.provider.util.FileUtils.decodeIfBase64;
 
 /**
  * <p>
@@ -112,12 +111,7 @@ public class GcpSecretManagerSEPSProvider
           Map<Parameter, CharSequence> parameterValues) {
 
     ParameterSet parameterSet = parseParameterValues(parameterValues);
-
-    byte[] walletBytes = getSecret(parameterValues).toByteArray();
-
-    if (FileUtils.isBase64Encoded(walletBytes)) {
-      walletBytes = Base64.getDecoder().decode(walletBytes);
-    }
+    byte[] walletBytes = decodeIfBase64(getSecret(parameterValues).toByteArray());
 
     char[] walletPassword = parameterSet.getOptional(PASSWORD) != null
             ? parameterSet.getOptional(PASSWORD).toCharArray()

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpSecretManagerTCPSProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpSecretManagerTCPSProvider.java
@@ -40,16 +40,15 @@ package oracle.jdbc.provider.gcp.resource;
 
 import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.provider.resource.ResourceParameter;
-import oracle.jdbc.provider.util.FileUtils;
 import oracle.jdbc.provider.util.TlsUtils;
 import oracle.jdbc.spi.TlsConfigurationProvider;
 
 import javax.net.ssl.SSLContext;
-import java.util.Base64;
 import java.util.Map;
 
 import static oracle.jdbc.provider.util.CommonParameters.PASSWORD;
 import static oracle.jdbc.provider.util.CommonParameters.TYPE;
+import static oracle.jdbc.provider.util.FileUtils.decodeIfBase64;
 
 /**
  * <p>
@@ -110,12 +109,7 @@ public class GcpSecretManagerTCPSProvider
   public SSLContext getSSLContext(Map<Parameter, CharSequence> parameterValues) {
     try {
       ParameterSet parameterSet = parseParameterValues(parameterValues);
-
-      byte[] fileBytes = getSecret(parameterValues).toByteArray();
-
-      if (FileUtils.isBase64Encoded(fileBytes)) {
-        fileBytes = Base64.getDecoder().decode(fileBytes);
-      }
+      byte[] fileBytes = decodeIfBase64(getSecret(parameterValues).toByteArray());
 
       char[] password = parameterSet.getOptional(PASSWORD) != null
               ? parameterSet.getOptional(PASSWORD).toCharArray()


### PR DESCRIPTION
This PR refactors the AWS and GCP provider modules to use `decodeIfBase64` for Base64 decoding, eliminating duplicated decoding logic. 
The changes apply to `SecretsManagerConnectionStringProvider` (AWS) and GCP resource providers (`GcpSecretManagerConnectionStringProvider`, `GcpSecretManagerSEPSProvider`, `GcpSecretManagerTCPSProvider`),