### PR TITLE
Fix wallet_location JSON Object handling

### DIFF
--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/configuration/AwsJsonSecretsManagerProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/configuration/AwsJsonSecretsManagerProvider.java
@@ -42,12 +42,11 @@ import oracle.jdbc.provider.aws.secrets.SecretsManagerFactory;
 import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.spi.OracleConfigurationSecretProvider;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Map;
 
 import static oracle.jdbc.provider.aws.configuration.AwsConfigurationParameters.FIELD_NAME;
 import static oracle.jdbc.provider.aws.configuration.AwsSecretsManagerConfigurationProvider.PARAMETER_SET_PARSER;
+import static oracle.jdbc.provider.util.FileUtils.toBase64EncodedCharArray;
 
 public class AwsJsonSecretsManagerProvider
     implements OracleConfigurationSecretProvider {
@@ -96,9 +95,7 @@ public class AwsJsonSecretsManagerProvider
     String extractedSecret = AwsSecretExtractor.extractSecret(secretString,
       fieldName);
 
-    return Base64.getEncoder()
-        .encodeToString(extractedSecret.getBytes(StandardCharsets.UTF_8))
-        .toCharArray();
+    return toBase64EncodedCharArray(extractedSecret);
   }
 
   @Override

--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -103,6 +103,51 @@ The sample code below executes as expected with the previous configuration (and 
     if (rs.next())
       System.out.println("select sysdate from dual: " + rs.getString(1));
 ```
+### Password JSON Object
+
+For the JSON type of provider (Azure App Configuration, Azure Key Vault, HTTP/HTTPS, File) the password is an object itself with the following spec:
+
+- `type`
+  - Mandatory
+  - Possible values
+    - `azurevault` (Azure Key Vault)
+    - `ocivault` (OCI Vault)
+    - `base64` (Base64)
+    - `awssecretsmanager` (AWS Secrets Manager)
+    - `hcpvaultdedicated` (HCP Vault Dedicated)
+    - `hcpvaultsecret` (HCP Vault Secrets)
+    - `gcpsecretmanager` (GCP Secret Manager)
+- `value`
+  - Mandatory
+  - Possible values
+    - Azure Key Vault URI (if azurevault)  
+    - OCID of the secret (if ocivault)
+    - Base64 Encoded password (if base64)
+    - AWS Secret name (if awssecretsmanager)
+    - Secret path (if hcpvaultdedicated)
+    - Secret name (if hcpvaultsecret)
+    - Secret name (if gcpsecretmanager)
+- `authentication`
+  - Optional
+  - Possible Values
+    - method
+    - optional parameters (depends on the cloud provider).
+
+### Wallet_location JSON Object
+
+The `oracle.net.wallet_location` connection property is not allowed in the `jdbc` object due to security reasons. Instead, users should use the `wallet_location` object to specify the wallet in the configuration.
+
+For the JSON type of provider (Azure App Configuration, HTTPS, File) the `wallet_location` is an object itself with the same spec as the [password JSON object](#password-json-object) mentioned above.
+
+The value stored in the secret should be the Base64 representation of the bytes in `cwallet.sso`. This is equivalent to setting the `oracle.net.wallet_location` connection property in a regular JDBC application using the following format:
+
+```
+data:;base64,<Base64 representation of the bytes in cwallet.sso>
+```
+
+<i>*Note: When storing a wallet in Azure Key Vault, store the raw Base64-encoded wallet bytes directly. The provider will automatically detect and handle the encoding correctly.</i>
+
+
 ## Azure Vault Config Provider
 Similar to [OCI Vault Config Provider](../ojdbc-provider-oci/README.md#oci-vault-config-provider), JSON Payload can also be stored in the content of Azure Key Vault Secret.
 The Oracle Data Source uses a new prefix `jdbc:oracle:thin:@config-azurevault://`. Users only need to indicate the Vault Secret’s secret identifier using the following syntax, where option-value pairs separated by `&` are optional authentication parameters that vary by provider:

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureVaultSecretProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureVaultSecretProvider.java
@@ -44,8 +44,9 @@ import oracle.jdbc.provider.parameter.Parameter;
 import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.provider.parameter.ParameterSetParser;
 
-import java.util.Base64;
 import java.util.Map;
+
+import static oracle.jdbc.provider.util.FileUtils.toBase64EncodedCharArray;
 
 /**
  * A provider of Secret values from Azure Key Vault.
@@ -97,9 +98,7 @@ public final class AzureVaultSecretProvider
       .getContent()
       .getValue();
 
-    return Base64.getEncoder()
-      .encodeToString(secretString.getBytes())
-      .toCharArray();
+    return toBase64EncodedCharArray(secretString);
   }
 
   /**

--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/FileUtils.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/FileUtils.java
@@ -38,6 +38,7 @@
 
 package oracle.jdbc.provider.util;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 /**
@@ -66,5 +67,26 @@ public final class FileUtils {
   public static byte[] decodeIfBase64(byte[] input) {
     return isBase64Encoded(input) ? Base64.getDecoder().decode(input)
             : input;
+  }
+
+  /**
+   * Converts a secret string to a Base64-encoded char array.
+   * If the secret is already Base64-encoded, it is returned as a char array.
+   * Otherwise, it is encoded to Base64.
+   *
+   * @param secretString The secret string to process
+   * @return A char array containing the Base64-encoded secret,
+   * or null if the input is null
+   */
+  public static char[] toBase64EncodedCharArray(String secretString) {
+    if (secretString == null) {
+      return null;
+    }
+    byte[] secretBytes = secretString.getBytes(StandardCharsets.UTF_8);
+    if (isBase64Encoded(secretBytes)) {
+      return secretString.toCharArray();
+    } else {
+      return Base64.getEncoder().encodeToString(secretBytes).toCharArray();
+    }
   }
 }

--- a/ojdbc-provider-gcp/README.md
+++ b/ojdbc-provider-gcp/README.md
@@ -109,6 +109,10 @@ And the JSON Payload for the file **payload_ojdbc_objectstorage.json** in the **
     "type": "gcpsecretmanager",
     "value": "projects/138028249883/secrets/test-secret/versions/1"
   },
+  "wallet_location": {
+    "type": "gcpsecretmanager",
+    "value": "projects/myproject/secrets/wallet-secret/versions/1"
+  },
   "jdbc": {
     "oracle.jdbc.ReadTimeout": 1000,
     "defaultRowPrefetch": 20,
@@ -133,26 +137,49 @@ The sample code below executes as expected with the previous configuration.
 
 For the JSON type of provider (GCP Object Storage, HTTP/HTTPS, File) the password is an object itself with the following spec:
 
-- type
+- `type`
   - Mandatory
   - Possible values
-    - ocivault
-    - azurevault
-    - base64
-    - gcpsecretmanager
-- value
+    - `gcpsecretmanager` (GCP Secret Manager)
+    - `ocivault` (OCI Vault)
+    - `azurevault` (Azure Key Vault)
+    - `base64` (Base64)
+    - `awssecretsmanager` (AWS Secrets Manager)
+    - `hcpvaultdedicated` (HCP Vault Dedicated)
+    - `hcpvaultsecret` (HCP Vault Secrets)
+- `value`
   - Mandatory
   - Possible values
+    - Secret name (if gcpsecretmanager)
     - OCID of the secret (if ocivault)
     - Azure Key Vault URI (if azurevault)
     - Base64 Encoded password (if base64)
-    - GCP resource name (if gcpsecretmanager)
-    - Text
-- authentication
+    - AWS Secret name (if awssecretsmanager)
+    - Secret path (if hcpvaultdedicated)
+    - Secret name (if hcpvaultsecret)
+- `authentication`
   - Optional
   - Possible Values
     - method
     - optional parameters (depends on the cloud provider).
+
+### Wallet_location JSON Object
+
+The `oracle.net.wallet_location` connection property is not allowed in the "jdbc" object due to security reasons. Instead, users should use the `wallet_location object to specify the wallet in the configuration.
+
+For the JSON type of provider (GCP Cloud Storage, HTTPS, File) the `wallet_location` is an object itself with the same spec as the [password JSON object](#password-json-object) mentioned above.
+
+The value stored in the secret can be either:
+
+  - The Base64 representation of the bytes in cwallet.sso.
+  - The raw bytes of the cwallet.sso file, stored as an imported file.
+
+In both cases, the provider will automatically handle the content. If the secret contains raw bytes (e.g., an imported cwallet.sso file), the provider will perform Base64 encoding as needed. The resulting format is equivalent to setting the oracle.net.wallet_location connection property in a regular JDBC application using the following format:
+```
+data:;base64,<Base64 representation of the bytes in cwallet.sso>
+```
+
+<i>*Note: When storing a wallet in GCP Secret Manager, you can either store the raw bytes of the cwallet.sso file directly or provide the Base64-encoded string. The provider will detect the format and handle the encoding appropriately.</i>
 
 ## GCP Secret Manager Config Provider
 Apart from GCP Cloud Storage, users can also store JSON Payload in the content of GCP Secret Manager secret. Users need to indicate the resource name:

--- a/ojdbc-provider-hashicorp/README.md
+++ b/ojdbc-provider-hashicorp/README.md
@@ -450,11 +450,12 @@ jdbc:oracle:thin:@config-hcpvaultsecret://secret-name?HCP_APP_NAME=app-name&key=
 
 ### JSON Payload format
 
-There are 3 fixed values that are looked at the root level:
+There are 4 fixed values that are looked at the root level:
 
 - `connect_descriptor` (required)
 - `user` (optional)
 - `password` (optional)
+- `wallet_location` (optional)
 
 The rest are dependent on the driver, in our case `/jdbc`. The key-value pairs that are under the `/jdbc` prefix will be applied to a `DataSource`. These keys correspond to the properties defined in the [OracleConnection](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html) interface.
 
@@ -473,7 +474,12 @@ And the JSON Payload for the secret **test_config** stored in the HCP Vault Dedi
   "password": {
     "type": "hcpvaultdedicated",
     "value": "/v1/namespace/secret/data/password",
-    "field_name": "db-password"
+    "field_name": "db-password" // Optional: Only needed when the secret is structured and contains multiple key-value pairs.
+  },
+  "wallet_location": {
+    "type": "hcpvaultdedicated",
+    "value": "/v1/namespace/secret/data/wallet",
+    "field_name": "wallet_field" // Optional: Only needed when the secret is structured and contains multiple key-value pairs.
   },
   "jdbc": {
     "oracle.jdbc.ReadTimeout": 1000,
@@ -509,6 +515,10 @@ And the JSON Payload for a secret stored within the application app_name in the 
     "type": "hcpvaultsecret",
     "value": "secret-name"
   },
+  "wallet_location": {
+    "type": "hcpvaultsecret",
+    "value": "wallet-secret"
+  },
   "jdbc": {
     "oracle.jdbc.ReadTimeout": 1000,
     "defaultRowPrefetch": 20,
@@ -533,24 +543,27 @@ The sample code below executes as expected with the previous configuration.
 
 For the JSON type of provider (HCP Vault Dedicated, HCP Vault Secrets, HTTP/HTTPS, File), the password is an object itself with the following spec:
 
-- type
+- `type`
     - Mandatory
     - Possible values
-        - ocivault
-        - azurevault
-        - base64
-        - hcpvaultdedicated
-        - hcpvaultsecret
-- value
+      - `hcpvaultdedicated` (HCP Vault Dedicated)
+      - `hcpvaultsecret` (HCP Vault Secrets) 
+      - `ocivault` (OCI Vault)
+      - `azurevault` (Azure Key Vault)
+      - `base64` (Base64)
+      - `awssecretsmanager` (AWS Secrets Manager)
+      - `gcpsecretmanager` (GCP Secret Manager)
+- `value`
     - Mandatory
     - Possible values
-        - OCID of the secret (if ocivault)
-        - Azure Key Vault URI (if azurevault)
-        - Base64 Encoded password (if base64)
-        - Secret path (if hcpvaultdedicated)
-        - Secret name (if hcpvaultsecret)
-        - Text
-- field_name (HCP Vault Dedicated only)
+      - Secret path (if hcpvaultdedicated)
+      - Secret name (if hcpvaultsecret)
+      - OCID of the secret (if ocivault)
+      - Azure Key Vault URI (if azurevault)
+      - Base64 Encoded password (if base64)
+      - AWS Secret name (if awssecretsmanager)
+      - Secret name (if gcpsecretmanager)
+- `field_name` (HCP Vault Dedicated only)
     - Optional
     - Description: Specifies the key within the secret JSON object to retrieve the password value.
       For example, if the secret contains `{ "db-password": "mypassword" }`,
@@ -559,11 +572,25 @@ For the JSON type of provider (HCP Vault Dedicated, HCP Vault Secrets, HTTP/HTTP
       - If `field_name` is **specified**, its corresponding value is extracted.
       - If the **secret contains only one key-value pair**, that value is **automatically used**.
       - If `field_name` is **missing** and **multiple keys exist**, an **error is thrown**.
-- authentication
+- `authentication`
     - Optional
     - Possible Values
         - method
         - optional parameters (depends on the cloud provider).
+
+### Wallet_location JSON Object
+
+The `oracle.net.wallet_location` connection property is not allowed in the `jdbc` object due to security reasons. Instead, users should use the `wallet_location` object to specify the wallet in the configuration.
+
+For the JSON type of provider (HCP Vault Dedicated, HCP Vault Secrets, HTTPS, File) the `wallet_location` is an object itself with the same spec as the [password JSON object](#password-json-object) mentioned above.
+
+The value stored in the secret should be the Base64 representation of the bytes in `cwallet.sso`. This is equivalent to setting the `oracle.net.wallet_location` connection property in a regular JDBC application using the following format:
+
+```
+data:;base64,<Base64 representation of the bytes in cwallet.sso>
+```
+
+<i>*Note: When storing a wallet in HCP Vault Dedicated or HCP Vault Secrets, store the raw Base64-encoded wallet bytes directly. The provider will automatically detect and handle the encoding correctly.</i>
 
 ## Resource Providers
 

--- a/ojdbc-provider-hashicorp/src/main/java/oracle/jdbc/provider/hashicorp/hcpvaultdedicated/configuration/DedicatedVaultJsonSecretProvider.java
+++ b/ojdbc-provider-hashicorp/src/main/java/oracle/jdbc/provider/hashicorp/hcpvaultdedicated/configuration/DedicatedVaultJsonSecretProvider.java
@@ -44,12 +44,15 @@ import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.spi.OracleConfigurationSecretProvider;
 import oracle.sql.json.OracleJsonObject;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 
 import static oracle.jdbc.provider.hashicorp.hcpvaultdedicated.authentication.DedicatedVaultParameters.FIELD_NAME;
 import static oracle.jdbc.provider.hashicorp.hcpvaultdedicated.authentication.DedicatedVaultParameters.PARAMETER_SET_PARSER;
 import static oracle.jdbc.provider.hashicorp.util.JsonUtil.extractSecret;
+import static oracle.jdbc.provider.util.FileUtils.isBase64Encoded;
+import static oracle.jdbc.provider.util.FileUtils.toBase64EncodedCharArray;
 
 /**
  * <p>
@@ -98,9 +101,7 @@ public class DedicatedVaultJsonSecretProvider implements OracleConfigurationSecr
     String fieldName = parameterSet.getOptional(FIELD_NAME);
     String extractedSecret = extractSecret(secretJsonObj, fieldName);
 
-    return Base64.getEncoder()
-      .encodeToString(extractedSecret.getBytes())
-      .toCharArray();
+    return toBase64EncodedCharArray(extractedSecret);
   }
 
   @Override

--- a/ojdbc-provider-hashicorp/src/main/java/oracle/jdbc/provider/hashicorp/hcpvaultsecret/configuration/HcpVaultJsonVaultProvider.java
+++ b/ojdbc-provider-hashicorp/src/main/java/oracle/jdbc/provider/hashicorp/hcpvaultsecret/configuration/HcpVaultJsonVaultProvider.java
@@ -40,6 +40,7 @@ package oracle.jdbc.provider.hashicorp.hcpvaultsecret.configuration;
 
 import oracle.jdbc.provider.hashicorp.hcpvaultsecret.secrets.HcpVaultSecretsManagerFactory;
 import oracle.jdbc.provider.parameter.ParameterSet;
+import oracle.jdbc.provider.util.FileUtils;
 import oracle.jdbc.spi.OracleConfigurationSecretProvider;
 
 import java.nio.charset.StandardCharsets;
@@ -47,6 +48,8 @@ import java.util.Base64;
 import java.util.Map;
 
 import static oracle.jdbc.provider.hashicorp.hcpvaultsecret.authentication.HcpVaultSecretParameters.PARAMETER_SET_PARSER;
+import static oracle.jdbc.provider.util.FileUtils.toBase64EncodedCharArray;
+
 /**
  * <p>
  * Implementation of {@link OracleConfigurationSecretProvider} for
@@ -83,9 +86,7 @@ public class HcpVaultJsonVaultProvider implements OracleConfigurationSecretProvi
       .request(parameterSet)
       .getContent();
 
-    String base64Encoded = Base64.getEncoder()
-            .encodeToString(secretString.getBytes(StandardCharsets.UTF_8));
-    return base64Encoded.toCharArray();
+    return toBase64EncodedCharArray(secretString);
   }
 
   @Override

--- a/ojdbc-provider-oci/README.md
+++ b/ojdbc-provider-oci/README.md
@@ -157,19 +157,21 @@ For the JSON type of provider (OCI Object Storage, HTTPS, File) the password is 
 - `type`
   - Mandatory
   - Possible values:
-    - `ocivault`
-    - `azurevault`
-    - `base64`
-    - `awssecretsmanager`
-    - `hcpvaultdedicated`
-    - `hcpvaultsecret`
+    - `ocivault` (OCI Vault)
+    - `gcpsecretmanager` (GCP Secret Manager)
+    - `azurevault` (Azure Key Vault)
+    - `base64` (Base64)
+    - `awssecretsmanager` (AWS Secrets Manager)
+    - `hcpvaultdedicated` (HCP Vault Dedicated)
+    - `hcpvaultsecret` (HCP Vault Secrets)
 - `value`
   - Mandatory
   - Possible values:
     - OCID of the secret (if ocivault)
+    - Secret name (if gcpsecretmanager)
     - Azure Key Vault URI (if azurevault)
     - Base64 Encoded password (if base64)
-    - AWS resource name of the secret  (if awssecretsmanager)
+    - AWS Secret name (if awssecretsmanager)
     - Secret path (if hcpvaultdedicated)
     - Secret name (if hcpvaultsecret)
 - `authentication`


### PR DESCRIPTION
This PR fixes issues with the `wallet_location` JSON object in Azure, HashiCorp (Vault Dedicated and Secrets), and AWS providers. It ensures `cwallet.sso` files are not encoded in Base64 twice and adds clear, comprehensive documentation for all providers (AWS, Azure, GCP, HashiCorp, OCI).