### PR TITLE
Fix fallback to config file when partial OCI API Key credentials are provided (Fixes #159)

### DIFF
--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/authentication/AuthenticationDetailsFactory.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/authentication/AuthenticationDetailsFactory.java
@@ -239,23 +239,24 @@ public final class AuthenticationDetailsFactory
    * Returns authentication details using the following API key-based
    * methods:
    * <ol>
-   *   <li>Simple authentication: if any of the credentials, including tenant ID
-   *       , user ID, fingerprint, private key, or passphrase, are provided in
-   *       the given {@code parameters}</li>
+   *   <li>Simple authentication: if all required credentials (tenant ID,
+   *   user ID, fingerprint, and private key are provided in the given
+   *   {@code parameters}</li>
    *   <li>Config File (API key) authentication: otherwise</li>
    * </ol>
    * @return API key-based authentication details
    */
   private static AuthenticationDetailsProvider
     apiKeyBasedAuthentication(ParameterSet parameters) {
-    if (parameters.contains(TENANT_ID)
-      || parameters.contains(USER_ID)
-      || parameters.contains(FINGERPRINT)
-      || parameters.contains(PRIVATE_KEY)
-      || parameters.contains(PASS_PHRASE)
-      || parameters.contains(REGION)) {
+    boolean hasAllRequiredKeys =
+      parameters.contains(TENANT_ID)
+      && parameters.contains(USER_ID)
+      && parameters.contains(FINGERPRINT)
+      && parameters.contains(PRIVATE_KEY);
+
+    if(hasAllRequiredKeys)
       return simpleAuthentication(parameters);
-    }
+
     return configFileAuthentication(parameters);
   }
 

--- a/ojdbc-provider-oci/src/test/java/oracle/jdbc/provider/oci/AuthenticationDetailsFactoryTest.java
+++ b/ojdbc-provider-oci/src/test/java/oracle/jdbc/provider/oci/AuthenticationDetailsFactoryTest.java
@@ -73,6 +73,17 @@ public class AuthenticationDetailsFactoryTest {
   }
 
   /**
+   * Verifies partial API_KEY credentials fallback to config file.
+   */
+  @Test
+  public void testApiKeyPartialCredentials() {
+    verifyAuthenticationDetails(
+      buildParameterSet(AuthenticationMethod.API_KEY)
+        .add("Test OCI_USER", AuthenticationDetailsFactory.USER_ID, "dummy-user-id")
+        .build());
+  }
+
+  /**
    * Verifies {@link AuthenticationMethod#CLOUD_SHELL}
    */
   @Test


### PR DESCRIPTION
Fixes #159 

When some OCI API Key parameters (like OCI_USER or OCI_TENANCY) are provided without the full set, an IllegalStateException was thrown.

This update changes the logic to check if all required fields (TENANCY, USER, FINGERPRINT, PRIVATE_KEY) are present. If not, it falls back to config file authentication instead of throwing an exception.

Also added a test case to verify this behavior.
