### PR TITLE
Fix AWS SecretsManager providers to handle empty fieldName when secret is non-JSON

### DIFF
--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/secrets/AwsSecretExtractor.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/secrets/AwsSecretExtractor.java
@@ -86,23 +86,24 @@ public class AwsSecretExtractor {
    * {@code fieldName} is provided
    */
   public static String extractSecret(String secretString, String fieldName) {
+    String normalizedFieldName = (fieldName != null && fieldName.trim().isEmpty()) ? null : fieldName;
     try {
       OracleJsonObject jsonObject = JSON_FACTORY.createJsonTextValue(
         new ByteArrayInputStream(secretString.getBytes(StandardCharsets.UTF_8))
       ).asJsonObject();
 
-      if (fieldName != null) {
+      if (normalizedFieldName != null) {
         if (!jsonObject.containsKey(fieldName)) {
-          throw new IllegalStateException("Field '" + fieldName + "' not found in secret JSON.");
+          throw new IllegalStateException("Field '" + normalizedFieldName + "' not found in secret JSON.");
         }
-        return jsonObject.get(fieldName).asJsonString().getString();
+        return jsonObject.get(normalizedFieldName).asJsonString().getString();
       } else if (jsonObject.size() == 1) {
         return jsonObject.values().iterator().next().asJsonString().getString();
       } else {
         throw new IllegalStateException("FIELD_NAME is required when multiple keys exist in the secret JSON");
       }
     } catch (OracleJsonException e) {
-      if (fieldName != null) {
+      if (normalizedFieldName != null) {
         throw new IllegalStateException("FIELD_NAME provided, but secret is not valid JSON.");
       }
       // Accept fallback to plain text only when fieldName is NOT specified

--- a/ojdbc-provider-aws/src/test/java/oracle/provider/aws/resource/SecretsManagerConnectionStringProviderTest.java
+++ b/ojdbc-provider-aws/src/test/java/oracle/provider/aws/resource/SecretsManagerConnectionStringProviderTest.java
@@ -122,4 +122,20 @@ public class SecretsManagerConnectionStringProviderTest {
     assertThrows(IllegalArgumentException.class, () ->
             PROVIDER.getConnectionString(parameterValues));
   }
+
+  @Test
+  public void testValidAliasWithEmptyFieldNameOnPlainTextSecret() {
+    Map<String, String> testParameters = new HashMap<>();
+    testParameters.put("secretName",
+      TestProperties.getOrAbort(AwsTestProperty.TNSNAMES_SECRET_NAME));
+    testParameters.put("tnsAlias",
+      TestProperties.getOrAbort(AwsTestProperty.TNS_ALIAS));
+    testParameters.put("awsRegion",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_REGION));
+    testParameters.put("fieldName", "");
+
+    Map<Parameter, CharSequence> parameterValues = createParameterValues(PROVIDER, testParameters);
+    assertNotNull(PROVIDER.getConnectionString(parameterValues));
+  }
+
 }

--- a/ojdbc-provider-aws/src/test/java/oracle/provider/aws/resource/SecretsManagerSepsProviderTest.java
+++ b/ojdbc-provider-aws/src/test/java/oracle/provider/aws/resource/SecretsManagerSepsProviderTest.java
@@ -229,4 +229,19 @@ public class SecretsManagerSepsProviderTest {
     assertThrows(IllegalStateException.class, () -> PASSWORD_PROVIDER.getPassword(values));
   }
 
+  @Test
+  public void testValidSepsWithEmptyFieldNameOnPlainTextSecret() {
+    Map<String, String> testParameters = new HashMap<>();
+    testParameters.put("secretName",
+      TestProperties.getOrAbort(AwsTestProperty.SSO_SEPS_WALLET_SECRET_NAME));
+    testParameters.put("awsRegion",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_REGION));
+    testParameters.put("fieldName", "");
+
+    Map<Parameter, CharSequence> parameterValues = createParameterValues(USERNAME_PROVIDER,
+            testParameters);
+    assertNotNull(USERNAME_PROVIDER.getUsername(parameterValues));
+  }
+
+
 }

--- a/ojdbc-provider-aws/src/test/java/oracle/provider/aws/resource/SecretsManagerTcpsProviderTest.java
+++ b/ojdbc-provider-aws/src/test/java/oracle/provider/aws/resource/SecretsManagerTcpsProviderTest.java
@@ -183,4 +183,21 @@ public class SecretsManagerTcpsProviderTest {
     assertThrows(IllegalStateException.class, () ->
             PROVIDER.getSSLContext(parameterValues));
   }
+
+  @Test
+  public void testValidTcpsWithEmptyFieldNameOnPlainTextSecret() {
+    Map<String, String> testParameters = new HashMap<>();
+    testParameters.put("secretName",
+      TestProperties.getOrAbort(AwsTestProperty.PEM_WALLET_SECRET_NAME));
+    testParameters.put("walletPassword",
+      TestProperties.getOrAbort(AwsTestProperty.WALLET_PASSWORD));
+    testParameters.put("type", "PEM");
+    testParameters.put("awsRegion",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_REGION));
+    testParameters.put("fieldName", "");
+
+    Map<Parameter, CharSequence> parameterValues = createParameterValues(PROVIDER, testParameters);
+    assertNotNull(PROVIDER.getSSLContext(parameterValues));
+  }
+
 }


### PR DESCRIPTION
Fixes #188 

When a secret stored in AWS Secrets Manager contains plain text and the `fieldName` parameter is set to an empty string, an IllegalStateException was previously thrown.

This PR solves the problem by ensuring that the `fieldName` parameter is only used when it's explicitly provided and not empty. 

Also added test cases for all resource providers to verify this behavior.
