### PR TITLE
Update wallet_location documentation to include PEM support and password handling

### DIFF
--- a/ojdbc-provider-aws/README.md
+++ b/ojdbc-provider-aws/README.md
@@ -161,10 +161,23 @@ The `oracle.net.wallet_location` connection property is not allowed in the `jdbc
 
 For the JSON type of provider (AWS S3, HTTPS, File) the wallet_location is an object itself with the same spec as the [password JSON object](#password-json-object) mentioned above.
 
-The value stored in the secret should be the Base64 representation of the bytes in `cwallet.sso`. This is equivalent to setting the `oracle.net.wallet_location` connection property in a regular JDBC application using the following format:
+The value stored in the secret should be the Base64 representation of of a supported wallet file. This is equivalent to setting the `oracle.net.wallet_location` connection property in a regular JDBC application using the following format:
 
 ```
-data:;base64,<Base64 representation of the bytes in cwallet.sso>
+data:;base64,<Base64 representation of the wallet file>
+```
+
+#### Supported formats
+- `cwallet.sso` (SSO wallet)
+- `ewallet.pem` (PEM wallet)
+
+If the PEM wallet is encrypted, you must also set the wallet password using the `oracle.net.wallet_password` property.
+This property should be included inside the jdbc object of the JSON payload:
+
+```
+"jdbc": {
+  "oracle.net.wallet_password": "<your-password>"
+}
 ```
 
 <i>*Note: When storing a wallet in AWS Secrets Manager, store the raw Base64-encoded wallet bytes directly. The provider will automatically detect and handle the encoding correctly.</i>

--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -139,10 +139,23 @@ The `oracle.net.wallet_location` connection property is not allowed in the `jdbc
 
 For the JSON type of provider (Azure Key Vault, HTTPS, File) the `wallet_location` is an object itself with the same spec as the [password JSON object](#password-json-object) mentioned above.
 
-The value stored in the secret should be the Base64 representation of the bytes in `cwallet.sso`. This is equivalent to setting the `oracle.net.wallet_location` connection property in a regular JDBC application using the following format:
+The value stored in the secret should be the Base64 representation of a supported wallet file. This is equivalent to setting the `oracle.net.wallet_location` connection property in a regular JDBC application using the following format:
 
 ```
-data:;base64,<Base64 representation of the bytes in cwallet.sso>
+data:;base64,<Base64 representation of the wallet file>
+```
+
+#### Supported formats
+- `cwallet.sso` (SSO wallet)
+- `ewallet.pem` (PEM wallet)
+
+If the PEM wallet is encrypted, you must also set the wallet password using the `oracle.net.wallet_password` property.
+This property should be included inside the jdbc object of the JSON payload:
+
+```
+"jdbc": {
+  "oracle.net.wallet_password": "<your-password>"
+}
 ```
 
 <i>*Note: When storing a wallet in Azure Key Vault, store the raw Base64-encoded wallet bytes directly. The provider will automatically detect and handle the encoding correctly.</i>

--- a/ojdbc-provider-gcp/README.md
+++ b/ojdbc-provider-gcp/README.md
@@ -171,12 +171,25 @@ For the JSON type of provider (GCP Cloud Storage, HTTPS, File) the `wallet_locat
 
 The value stored in the secret can be either:
 
-  - The Base64 representation of the bytes in cwallet.sso.
-  - The raw bytes of the cwallet.sso file, stored as an imported file.
+  - The Base64 representation of a supported wallet file.
+  - The raw bytes of the wallet file, stored as an imported secret.
 
-In both cases, the provider will automatically handle the content. If the secret contains raw bytes (e.g., an imported cwallet.sso file), the provider will perform Base64 encoding as needed. The resulting format is equivalent to setting the oracle.net.wallet_location connection property in a regular JDBC application using the following format:
+In both cases, the provider will automatically handle the content. If the secret contains raw bytes (e.g., an imported `cwallet.sso` or `ewallet.pem` file), the provider will perform Base64 encoding as needed. The resulting format is equivalent to setting the oracle.net.wallet_location` connection property in a regular JDBC application using the following format:
 ```
-data:;base64,<Base64 representation of the bytes in cwallet.sso>
+data:;base64,<Base64 representation of the wallet file>
+```
+
+#### Supported formats
+- `cwallet.sso` (SSO wallet)
+- `ewallet.pem` (PEM wallet)
+
+If the PEM wallet is encrypted, you must also set the wallet password using the `oracle.net.wallet_password` property.
+This property should be included inside the jdbc object of the JSON payload:
+
+```
+"jdbc": {
+  "oracle.net.wallet_password": "<your-password>"
+}
 ```
 
 <i>*Note: When storing a wallet in GCP Secret Manager, you can either store the raw bytes of the cwallet.sso file directly or provide the Base64-encoded string. The provider will detect the format and handle the encoding appropriately.</i>

--- a/ojdbc-provider-hashicorp/README.md
+++ b/ojdbc-provider-hashicorp/README.md
@@ -584,10 +584,24 @@ The `oracle.net.wallet_location` connection property is not allowed in the `jdbc
 
 For the JSON type of provider (HCP Vault Dedicated, HCP Vault Secrets, HTTPS, File) the `wallet_location` is an object itself with the same spec as the [password JSON object](#password-json-object) mentioned above.
 
-The value stored in the secret should be the Base64 representation of the bytes in `cwallet.sso`. This is equivalent to setting the `oracle.net.wallet_location` connection property in a regular JDBC application using the following format:
+The value stored in the secret should be the Base64 representation of a supported wallet file.  This is equivalent to setting the `oracle.net.wallet_location` connection property in a regular JDBC application using the following format:
 
 ```
-data:;base64,<Base64 representation of the bytes in cwallet.sso>
+data:;base64,<Base64 representation of the wallet file>
+```
+
+
+#### Supported formats
+- `cwallet.sso` (SSO wallet)
+- `ewallet.pem` (PEM wallet)
+
+If the PEM wallet is encrypted, you must also set the wallet password using the `oracle.net.wallet_password` property.
+This property should be included inside the jdbc object of the JSON payload:
+
+```
+"jdbc": {
+  "oracle.net.wallet_password": "<your-password>"
+}
 ```
 
 <i>*Note: When storing a wallet in HCP Vault Dedicated or HCP Vault Secrets, store the raw Base64-encoded wallet bytes directly. The provider will automatically detect and handle the encoding correctly.</i>

--- a/ojdbc-provider-oci/README.md
+++ b/ojdbc-provider-oci/README.md
@@ -186,10 +186,23 @@ The "oracle.net.wallet_location" connection property is not allowed in the "jdbc
 
 For the JSON type of provider (OCI Object Storage, HTTPS, File) the wallet_location is an object itself with the same spec as the [password JSON object](#password-json-object) mentioned above.
 
-The value stored in the secret should be the Base64 representation of the bytes in cwallet.sso. This is equivalent to setting the "oracle.net.wallet_location" connection property in a regular JDBC application using the following format:
+The value stored in the secret should be the Base64 representation of a supported wallet file. This is equivalent to setting the "oracle.net.wallet_location" connection property in a regular JDBC application using the following format:
 
 ```
-data:;base64,<Base64 representation of the bytes in cwallet.sso>
+data:;base64,<Base64 representation of the wallet file>
+```
+
+#### Supported formats:
+- `cwallet.sso` (SSO Wallet)
+- `ewallet.pem`(PEM Wallet)
+
+If the PEM wallet is encrypted, you must also set the wallet password using the `oracle.net.wallet_password` property.
+This property should be included inside the "jdbc" object of the JSON payload.
+
+```
+"jdbc": {
+  "oracle.net.wallet_password": "<your-password>"
+}
 ```
 
 <i>*Note: When storing a wallet as a secret in OCI Vault, choose the Plain-Text secret type template instead of Base64 to prevent double decoding when the provider retrieves the value.</i> 


### PR DESCRIPTION
Clarified that both `cwallet.sso` and `ewallet.pem` (PEM) wallet formats are supported in the `wallet_location` object inside the centralized configuration JSON. Also added guidance for passing the wallet password via `jdbc.oracle.net.wallet_password` when using encrypted PEM wallets.
Applied the update consistently across OCI, AWS, Azure, GCP, and HCP provider sections.
