### PR TITLE
Improve Azure App Configuration error handling

### DIFF
--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/authentication/TokenCredentialFactory.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/authentication/TokenCredentialFactory.java
@@ -139,13 +139,14 @@ public final class TokenCredentialFactory
    * used are configured by the parameters of the given {@code parameters}.
    * Supported parameters are defined by the class variables in
    * {@link TokenCredentialFactory}.
-   * @param parameters parameters that configure credentials. Not null.
+   * @param parameterSet parameters that configure credentials. Not null.
    * @return Credentials configured by parameters
    */
   private static TokenCredential getCredential(ParameterSet parameterSet) {
 
     AzureAuthenticationMethod authenticationMethod =
-      parameterSet.getRequired(AUTHENTICATION_METHOD);
+      parameterSet.contains(AUTHENTICATION_METHOD)
+        ? parameterSet.getRequired(AUTHENTICATION_METHOD) : AzureAuthenticationMethod.DEFAULT;
 
     switch (authenticationMethod) {
       case DEFAULT:
@@ -227,7 +228,7 @@ public final class TokenCredentialFactory
    * the Azure SDK's
    * {@link com.azure.identity.EnvironmentCredential} class.
    * </p>
-   * @param parameterSet Optional parameters. Not null.
+   * @param parameters Optional parameters. Not null.
    * @return Credentials for a service principal. Not null.
    * @throws IllegalStateException If a required parameter is not configured.
    */

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderTest.java
@@ -146,6 +146,12 @@ class AzureAppConfigurationProviderTest {
     }
   }
 
+  @Test
+  public void testInvalidConfiguration() {
+    String invalidUrl = "jdbc:oracle:thin:@config-azure://invalid-config";
+    assertThrows(SQLException.class, () -> tryConnection(invalidUrl), "Should throw an SQLException");
+  }
+
   /**
    * Helper function: try to get connection form specified url
    */


### PR DESCRIPTION
Fixes: #195 

When a required Azure App Configuration parameter is missing or the URL is invalid, the driver previously threw unclear runtime exceptions. This update now detects missing or malformed parameters early and throws a concise SQLException indicating the bad configuration. A new unit test verifies that an empty or invalid URL fails fast with the expected SQLException.