### PR TITLE
Refactor samples to use one resource provider per example

### DIFF
--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/PasswordProviderAzureExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/PasswordProviderAzureExample.java
@@ -71,14 +71,6 @@ public class PasswordProviderAzureExample {
       connectionProps.put("oracle.jdbc.provider.password.vaultUrl", "https://me-vault-test.vault.azure.net");
       connectionProps.put("oracle.jdbc.provider.password.secretName", "db-password");
 
-      // TLS Configuration for secure connection
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration", "ojdbc-provider-azure-key-vault-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.vaultUrl",
-              "https://your-vault-url.vault.azure.net");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.secretName",
-              "your-wallet-base64-secret-name");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.type", "SSO");
-
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/SimpleConnectionStringProviderAzureExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/SimpleConnectionStringProviderAzureExample.java
@@ -74,15 +74,6 @@ public class SimpleConnectionStringProviderAzureExample {
       connectionProps.put("oracle.jdbc.provider.connectionString.tnsAlias",
         "YOUR_TNS_ALIAS");
 
-      // TLS Configuration for secure connection
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration", "ojdbc-provider-azure-key-vault-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.vaultUrl",
-              "https://your-vault-url.vault.azure.net");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.secretName",
-              "your-wallet-base64-secret-name");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.type",
-              "SSO");
-
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/SimpleSEPSWalletProviderAzureExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/SimpleSEPSWalletProviderAzureExample.java
@@ -73,15 +73,6 @@ public class SimpleSEPSWalletProviderAzureExample {
       connectionProps.put("oracle.jdbc.provider.password.secretName",
               "your-seps-secret-name");
 
-      // TLS Configuration for secure connection
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration", "ojdbc-provider-azure-key-vault-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.vaultUrl",
-              "https://your-vault-url.vault.azure.net");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.secretName",
-              "your-wallet-base64-secret-name");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.type",
-              "SSO");
-
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/SimpleSEPSWalletProviderWithIndexExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/SimpleSEPSWalletProviderWithIndexExample.java
@@ -80,15 +80,6 @@ public class SimpleSEPSWalletProviderWithIndexExample {
       connectionProps.put("oracle.jdbc.provider.username.connectionStringIndex","1");
       connectionProps.put("oracle.jdbc.provider.password.connectionStringIndex","1");
 
-      // TLS Configuration for secure connection
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration", "ojdbc-provider-azure-key-vault-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.vaultUrl",
-              "https://your-vault-url.vault.azure.net");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.secretName",
-              "your-wallet-base64-secret-name");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.type",
-              "SSO");
-
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/UsernameProviderAzureExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure/configuration/resource/UsernameProviderAzureExample.java
@@ -73,15 +73,6 @@ public class UsernameProviderAzureExample {
       connectionProps.put("oracle.jdbc.provider.username.vaultUrl", "https://me-vault-test.vault.azure.net");
       connectionProps.put("oracle.jdbc.provider.username.secretName", "db-username");
 
-      // TLS Configuration for secure connection
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration", "ojdbc-provider-azure-key-vault-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.vaultUrl",
-              "https://your-vault-url.vault.azure.net");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.secretName",
-              "your-wallet-base64-secret-name");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.type",
-              "SSO");
-
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/resource/SimpleConnectionStringProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/resource/SimpleConnectionStringProviderExample.java
@@ -72,13 +72,6 @@ public class SimpleConnectionStringProviderExample {
       connectionProps.put("oracle.jdbc.provider.connectionString.tnsAlias",
               "YOUR_TNS_ALIAS");
 
-      // TLS Configuration for secure connection
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration",
-              "ojdbc-provider-gcp-secretmanager-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.secretVersionName",
-              "projects/your-project-id/secrets/your-wallet-secret/versions/1");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.type", "SSO");
-
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/resource/SimpleSEPSWalletProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/resource/SimpleSEPSWalletProviderExample.java
@@ -81,13 +81,6 @@ public class SimpleSEPSWalletProviderExample {
       connectionProps.put("oracle.jdbc.provider.password.secretVersionName",
         "projects/{your-project-id}/secrets/{your-secret-name}/versions/{version-number}");
 
-      // TLS Configuration Provider
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration",
-        "ojdbc-provider-gcp-secretmanager-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.type","SSO");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.secretVersionName",
-        "projects/{your-project-id}/secrets/{your-secret-name}/versions/{version-number}");
-
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/resource/SimpleSEPSWalletProviderWithIndexExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/resource/SimpleSEPSWalletProviderWithIndexExample.java
@@ -88,12 +88,6 @@ public class SimpleSEPSWalletProviderWithIndexExample {
       connectionProps.put("oracle.jdbc.provider.username.connectionStringIndex","1");
       connectionProps.put("oracle.jdbc.provider.password.connectionStringIndex","1");
 
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration",
-              "ojdbc-provider-gcp-secretmanager-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.secretVersionName",
-              "projects/{your-project-id}/secrets/{your-secret-name}/versions/{version-number}");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.type","SSO");
-
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/resource/SimpleSecretManagerUsernameProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp/resource/SimpleSecretManagerUsernameProviderExample.java
@@ -70,12 +70,6 @@ public class SimpleSecretManagerUsernameProviderExample {
         "ojdbc-provider-gcp-secretmanager-username");
       connectionProps.put("oracle.jdbc.provider.username.secretVersionName",
         "projects/{your-project-id}/secrets/{your-secret-name}/versions/{version-number}");
-      // TLS Configuration Provider
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration",
-              "ojdbc-provider-gcp-secretmanager-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.type","SSO");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.secretVersionName",
-              "projects/{your-project-id}/secrets/{your-secret-name}/versions/{version-number}");
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oci/configuration/resource/SimpleConnectionStringProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oci/configuration/resource/SimpleConnectionStringProviderExample.java
@@ -72,12 +72,6 @@ public class SimpleConnectionStringProviderExample {
       connectionProps.put("oracle.jdbc.provider.connectionString.tnsAlias",
               "YOUR_TNS_ALIAS");
 
-      // TLS Configuration for secure connection
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration",
-              "ojdbc-provider-oci-database-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.ocid",
-              "ocid1.autonomousdatabase.oc1.phx.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oci/configuration/resource/SimpleDatabaseConnectionStringProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oci/configuration/resource/SimpleDatabaseConnectionStringProviderExample.java
@@ -36,11 +36,6 @@ public class SimpleDatabaseConnectionStringProviderExample {
       connectionProps.put("oracle.jdbc.provider.connectionString.ocid",
         "ocid1.autonomousdatabase.oc1.phx.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration",
-        "ojdbc-provider-oci-database-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.ocid",
-        "ocid1.autonomousdatabase.oc1.phx.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oci/configuration/resource/SimpleSEPSWalletProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oci/configuration/resource/SimpleSEPSWalletProviderExample.java
@@ -39,11 +39,6 @@ public class SimpleSEPSWalletProviderExample {
       connectionProps.put("oracle.jdbc.provider.password.ocid",
         "ocid1.vaultsecret.oc1.phx.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 
-      // TLS Configuration Provider
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration", "ojdbc-provider-oci-database-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.ocid",
-        "ocid1.autonomousdatabase.oc1.phx.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oci/configuration/resource/SimpleSEPSWalletProviderWithIndexExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oci/configuration/resource/SimpleSEPSWalletProviderWithIndexExample.java
@@ -44,12 +44,6 @@ public class SimpleSEPSWalletProviderWithIndexExample {
       connectionProps.put("oracle.jdbc.provider.password.ocid",
         "ocid1.vaultsecret.oc1.phx.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 
-      // TLS Configuration Provider
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration",
-        "ojdbc-provider-oci-database-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.ocid",
-        "ocid1.autonomousdatabase.oc1.phx.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-
       // Specify the connection string index
       connectionProps.put("oracle.jdbc.provider.username.connectionStringIndex","1");
       connectionProps.put("oracle.jdbc.provider.password.connectionStringIndex","1");

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oci/configuration/resource/SimpleVaultSecretPasswordProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oci/configuration/resource/SimpleVaultSecretPasswordProviderExample.java
@@ -27,9 +27,6 @@ public class SimpleVaultSecretPasswordProviderExample {
       connectionProps.put("oracle.jdbc.provider.password","ojdbc-provider-oci-vault-password");
       connectionProps.put("oracle.jdbc.provider.password.ocid",
         "ocid1.vaultsecret.oc1.phx.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration", "ojdbc-provider-oci-database-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.ocid",
-        "ocid1.autonomousdatabase.oc1.phx.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oci/configuration/resource/SimpleVaultSecretUsernameProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oci/configuration/resource/SimpleVaultSecretUsernameProviderExample.java
@@ -30,9 +30,6 @@ public class SimpleVaultSecretUsernameProviderExample {
       connectionProps.put("oracle.jdbc.provider.username","ojdbc-provider-oci-vault-username");
       connectionProps.put("oracle.jdbc.provider.username.ocid",
         "ocid1.vaultsecret.oc1.phx.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration", "ojdbc-provider-oci-database-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.ocid",
-        "ocid1.vaultsecret.oc1.phx.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {


### PR DESCRIPTION
This PR refactors all sample classes to use only one resource provider per example. Previously, some examples combined multiple providers (e.g., password and TLS), which could be confusing. By isolating each provider usage in its own example, users will have a clearer understanding of how to configure and test each provider individually.