### PR TITLE
Refs/heads/add resource providers for aws parameter store

### DIFF
--- a/ojdbc-provider-aws/README.md
+++ b/ojdbc-provider-aws/README.md
@@ -30,14 +30,22 @@ particular provider.
 <dl>
 <dt><a href="#aws-secrets-manager-username-provider">Secrets Manager Username Provider</a></dt>
 <dd>Provides a database username from AWS Secrets Manager</dd>
+<dt><a href="#aws-parameter-store-username-provider">Parameter Store Username Provider</a></dt>
+<dd>Provides a database username from AWS Parameter Store</dd>
 <dt><a href="#aws-secrets-manager-password-provider">Secrets Manager Password Provider</a></dt>
 <dd>Provides a database password from AWS Secrets Manager</dd>
+<dt><a href="#aws-parameter-store-password-provider">Parameter Store Password Provider</a></dt>
+<dd>Provides a database password from AWS Parameter Store</dd>
 <dt><a href="#aws-secrets-manager-connection-string-provider">Secrets Manager Connection String Provider</a></dt>
 <dd>Provides connection strings from a tnsnames.ora file stored in AWS Secrets Manager</dd>
+<dt><a href="#aws-parameter-store-connection-string-provider">Parameter Store Connection String Provider</a></dt>
+<dd>Provides connection strings from a tnsnames.ora file stored in AWS Parameter Store</dd>
 <dt><a href="#aws-secrets-manager-tcps-wallet-provider">Secrets Manager TCPS Wallet Provider</a></dt>
 <dd>Provides TCPS/TLS wallet from AWS Secrets Manager</dd>
 <dt><a href="#aws-secrets-manager-seps-wallet-provider">Secrets Manager SEPS Wallet Provider</a></dt>
 <dd>Provides SEPS (Secure External Password Store) wallet from AWS Secrets Manager</dd>
+<dt><a href="#aws-parameter-store-seps-wallet-provider">Parameter Store SEPS Wallet Provider</a></dt>
+<dd>Provides SEPS (Secure External Password Store) wallet from AWS Parameter Store</dd>
 <dt><a href="#common-parameters-for-resource-providers">Common Parameters for Resource Providers</a></dt>
 <dd>Common parameters supported by the resource providers</dd>
 </dl>
@@ -330,6 +338,37 @@ An example of a
 that configures this provider can be found in
 [example-vault.properties](example-aws-secretsmanager.properties).
 
+## AWS Parameter Store Username Provider
+
+The Parameter Store Username Provider provides Oracle JDBC with a database username stored in AWS Systems Manager Parameter Store. 
+This is a [Resource Provider](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/spi/OracleResourceProvider.html) identified
+by the name `ojdbc-provider-aws-parameter-store-username`.
+
+In addition to the set of [common parameters](#common-parameters-for-resource-providers),
+this provider also supports the parameters listed below.
+
+<table>
+<thead><tr>
+<th>Parameter Name</th>
+<th>Description</th>
+<th>Accepted Values</th>
+<th>Default Value</th>
+</tr></thead>
+<tbody>
+<tr>
+<td><code>parameterName</code></td>
+<td>The name of a parameter in AWS Parameter Store.</td>
+<td>Any valid parameter name.</td>
+<td><i>No default value. A value must be configured for this parameter.</i></td>
+</tr>
+</tbody>
+</table>
+
+An example of a
+[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
+that configures this provider can be found in
+[example-vault.properties](example-aws-parameterstore.properties).
+
 ## AWS Secrets Manager Password Provider
 The Secrets Manager Password Provider provides Oracle JDBC with a database password
 that is managed by the AWS Secrets Manager service. This is a [Resource Provider](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/spi/OracleResourceProvider.html)
@@ -379,6 +418,36 @@ An example of a
 [connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
 that configures this provider can be found in
 [example-vault.properties](example-aws-secretsmanager.properties).
+
+## AWS Parameter Store Password Provider
+
+The Parameter Store Password Provider provides Oracle JDBC with a database password stored in AWS Systems Manager Parameter Store.
+This is a [Resource Provider](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/spi/OracleResourceProvider.html) identified
+by the name `ojdbc-provider-aws-parameter-store-password`.
+
+In addition to the set of [common parameters](#common-parameters-for-resource-providers),
+this provider also supports the parameters listed below.
+<table>
+<thead><tr>
+<th>Parameter Name</th>
+<th>Description</th>
+<th>Accepted Values</th>
+<th>Default Value</th>
+</tr></thead>
+<tbody>
+<tr>
+<td><code>parameterName</code></td>
+<td>The name of a parameter in AWS Parameter Store.</td>
+<td>Any valid parameter name.</td>
+<td><i>No default value. A value must be configured for this parameter.</i></td>
+</tr>
+</tbody>
+</table>
+
+An example of a
+[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
+that configures this provider can be found in
+[example-vault.properties](example-aws-parameterstore.properties).
 
 ## AWS Secrets Manager TCPS Wallet Provider
 
@@ -542,6 +611,49 @@ The name of the key to extract from the secret when it is stored as a set of key
 
 An example of a [connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE) that configures this provider can be found in [example-secrets-manager-wallet.properties](example-aws-secretsmanager-wallet.properties.properties).
 
+## AWS Parameter Store SEPS Wallet Provider
+
+The SEPS Wallet Provider retrieves a SEPS wallet stored in AWS Parameter Store. 
+This is a [Resource Provider](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/spi/OracleResourceProvider.html) identified
+by the name `ojdbc-provider-aws-parameter-store-seps`.
+
+This provider works identically to the [AWS Secrets Manager SEPS Wallet Provider](#aws-secrets-manager-seps-wallet-provider)
+except that it uses a Parameter Store parameter instead of a Secrets Manager secret.
+
+In addition to the set of [common parameters](#common-parameters-for-resource-providers), this provider also supports the parameters listed below.
+
+<table>
+<thead><tr>
+<th>Parameter Name</th>
+<th>Description</th>
+<th>Accepted Values</th>
+<th>Default Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>parameterName</code></td>
+<td>The name of a parameter in AWS Parameter Store.</td>
+<td>Any valid parameter name.</td>
+<td><i>No default value. A value must be configured for this parameter.</i></td>
+</tr>
+<tr>
+<td><code>walletPassword</code></td>
+<td>Optional password for PKCS12 wallets.</td>
+<td>Any valid password</td>
+<td><i>None. Required if wallet is password-protected.</i></td>
+</tr>
+<tr>
+<td><code>connectionStringIndex</code></td>
+<td>Optional index to select specific credentials in SEPS wallet.</td>
+<td>Any positive integer (e.g., 1, 2, 3)</td>
+<td><i>None</i></td>
+</tr>
+</tbody>
+</table>
+
+An example of a [connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE) that configures this provider can be found in [example-parameter-store-wallet.properties](example-aws-parameterstore-wallet.properties).
+
 ## AWS Secrets Manager Connection String Provider
 
 The Connection String Provider provides Oracle JDBC with a connection string managed by the AWS Secrets Manager service.
@@ -606,6 +718,49 @@ In addition to the set of [common parameters](#common-parameters-for-resource-pr
 </table>
 
 An example of a [connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE) that configures this provider can be found in [example-aws-secretsmanager.properties](example-aws-secretsmanager.properties).
+
+## AWS Parameter Store Connection String Provider
+
+The Connection String Provider provides Oracle JDBC with a connection string managed by the AWS Systems Manager Parameter Store service.
+This is a [Resource Provider](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/spi/OracleResourceProvider.html) identified
+by the name `ojdbc-provider-aws-parameter-store-tnsnames`.
+
+This provider retrieves and decodes a `tnsnames.ora` file stored as a parameter value in AWS Parameter Store.
+
+You can store the contents of the `tnsnames.ora` file as:
+
+- A base64-encoded string containing the full contents of the `tnsnames.ora` file.
+
+- Plain text, by simply copying and pasting the contents directly into the parameter value.
+
+In addition to the set of [common parameters](#common-parameters-for-resource-providers), this provider also requires the parameters listed below.
+
+<table>
+<thead>
+  <tr>
+    <th>Parameter Name</th>
+    <th>Description</th>
+    <th>Accepted Values</th>
+    <th>Default Value</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td><code>parameterName</code></td> 
+    <td>The name of a parameter in AWS Systems Manager Parameter Store.</td> 
+    <td>Any valid parameter name.</td> 
+    <td><i>No default value. A value must be configured for this parameter.</i></td>
+  </tr>
+  <tr>
+    <td><code>tnsAlias</code></td>
+    <td>Specifies the alias to retrieve the appropriate connection string from the <code>tnsnames.ora</code> file.</td> 
+    <td>Any valid alias present in your <code>tnsnames.ora</code> file.</td>
+    <td><i>No default value. A value must be configured for this parameter.</i></td> 
+  </tr> 
+</tbody>
+</table>
+
+An example of a [connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE) that configures this provider can be found in [example-aws-parameterstore.properties](example-aws-parameterstore.properties).
 
 ## Common Parameters for Resource Providers
 

--- a/ojdbc-provider-aws/example-aws-parameterstore-wallet.properties
+++ b/ojdbc-provider-aws/example-aws-parameterstore-wallet.properties
@@ -1,0 +1,63 @@
+################################################################################
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or data
+# (collectively the "Software"), free of charge and under any and all copyright
+# rights in the Software, and any and all patent rights owned or freely
+# licensable by each licensor hereunder covering either (i) the unmodified
+# Software as contributed to or provided by such licensor, or (ii) the Larger
+# Works (as defined below), to deal in both
+#
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software (each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition:
+# The above copyright notice and either this complete permission notice or at
+# a minimum a reference to the UPL must be included in all copies or
+# substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+################################################################################
+
+# An example of a connection properties file that configures Oracle JDBC to
+# obtain SEPS credentials from AWS Parameter Store.
+#
+# This file can be located by Oracle JDBC using the "oracle.jdbc.config.file"
+# connection property. For details, see:
+# https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE
+
+# Configures the AWS Parameter Store SEPS Wallet Provider for both username and password.
+# The SEPS wallet parameter name, wallet password, and index are configured via
+# "SEPS_WALLET_PARAMETER_NAME", "SEPS_WALLET_PASSWORD", and "SEPS_CONNECTION_STRING_INDEX".
+oracle.jdbc.provider.username=ojdbc-provider-aws-parameter-store-seps
+oracle.jdbc.provider.username.parameterName=${SEPS_WALLET_PARAMETER_NAME}
+oracle.jdbc.provider.username.walletPassword=${SEPS_WALLET_PASSWORD}
+oracle.jdbc.provider.username.connectionStringIndex=${SEPS_CONNECTION_STRING_INDEX}
+oracle.jdbc.provider.username.awsRegion=${AWS_REGION}
+
+oracle.jdbc.provider.password=ojdbc-provider-aws-parameter-store-seps
+oracle.jdbc.provider.password.parameterName=${SEPS_WALLET_PARAMETER_NAME}
+oracle.jdbc.provider.password.walletPassword=${SEPS_WALLET_PASSWORD}
+oracle.jdbc.provider.password.connectionStringIndex=${SEPS_CONNECTION_STRING_INDEX}
+oracle.jdbc.provider.password.authenticationMethod=aws-default
+oracle.jdbc.provider.password.awsRegion=${AWS_REGION}
+
+
+

--- a/ojdbc-provider-aws/example-aws-parameterstore.properties
+++ b/ojdbc-provider-aws/example-aws-parameterstore.properties
@@ -1,0 +1,69 @@
+################################################################################
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or data
+# (collectively the "Software"), free of charge and under any and all copyright
+# rights in the Software, and any and all patent rights owned or freely
+# licensable by each licensor hereunder covering either (i) the unmodified
+# Software as contributed to or provided by such licensor, or (ii) the Larger
+# Works (as defined below), to deal in both
+#
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software (each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition:
+# The above copyright notice and either this complete permission notice or at
+# a minimum a reference to the UPL must be included in all copies or
+# substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+################################################################################
+
+# An example of a connection properties file that configures Oracle JDBC to
+# login using a username and password managed by AWS Parameter Store.
+#
+# This file can be located by Oracle JDBC using the "oracle.jdbc.config.file"
+# connection property. For details, see:
+# https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE
+
+# Configures the AWS Parameter Store Username Provider.
+# The parameter name is configured as an environment variable or JVM system property
+# named "USERNAME_PARAMETER_NAME". The AWS region is configured via "AWS_REGION".
+oracle.jdbc.provider.username=ojdbc-provider-aws-parameter-store-username
+oracle.jdbc.provider.username.parameterName=${USERNAME_PARAMETER_NAME}
+oracle.jdbc.provider.username.awsRegion=${AWS_REGION}
+
+# Configures the AWS Parameter Store Password Provider.
+# The parameter name is configured as an environment variable or JVM system property
+# named "PASSWORD_PARAMETER_NAME". The AWS region is configured via "AWS_REGION".
+oracle.jdbc.provider.password=ojdbc-provider-aws-parameter-store-password
+oracle.jdbc.provider.password.parameterName=${PASSWORD_PARAMETER_NAME}
+oracle.jdbc.provider.password.awsRegion=${AWS_REGION}
+
+# Configures the AWS Parameter Store Connection String Provider.
+# The parameter name and alias are configured as environment variables or JVM system properties
+# named "TNSNAMES_PARAMETER_NAME" and "TNS_ALIAS", respectively. The AWS region is configured via "AWS_REGION".
+oracle.jdbc.provider.connectionString=ojdbc-provider-aws-parameter-store-tnsnames
+oracle.jdbc.provider.connectionString.parameterName=${TNSNAMES_PARAMETER_NAME}
+oracle.jdbc.provider.connectionString.tnsAlias=${TNS_ALIAS}
+oracle.jdbc.provider.connectionString.awsRegion=${AWS_REGION}
+
+
+

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/AwsResourceParameterNames.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/AwsResourceParameterNames.java
@@ -35,25 +35,56 @@
  ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  ** SOFTWARE.
  */
-package oracle.provider.aws;
 
-public enum AwsTestProperty {
-  AWS_S3_URL,
-  AWS_SECRETS_MANAGER_URL,
-  AWS_APP_CONFIG_URL,
-  AWS_REGION,
-  DB_CREDENTIALS_SECRET_NAME,
-  TNSNAMES_SECRET_NAME,
-  TNS_ALIAS,
-  PKCS12_WALLET_SECRET_NAME,
-  WALLET_PASSWORD,
-  SSO_WALLET_SECRET_NAME,
-  PEM_WALLET_SECRET_NAME,
-  PKCS12_SEPS_WALLET_SECRET_NAME,
-  SSO_SEPS_WALLET_SECRET_NAME,
-  AWS_PARAMETER_STORE_URL,
-  AWS_PARAMETER_STORE_PASSWORD_NAME,
-  AWS_PARAMETER_STORE_TNSNAMES_NAME,
-  PKCS12_SEPS_WALLET_PARAMETER_NAME,
-  SSO_SEPS_WALLET_PARAMETER_NAME
+package oracle.jdbc.provider.aws.resource;
+
+/**
+ * Centralized parameter name constants used by all AWS resource providers.
+ */
+public final class AwsResourceParameterNames {
+
+  private AwsResourceParameterNames() {}
+
+  // Common parameters
+  /**
+   *  The AWS region where the resource is stored (e.g., eu-north-1).
+   */
+  public static final String AWS_REGION = "awsRegion";
+
+  /**
+   *  The alias used to retrieve a connection string from tnsnames.ora.
+   */
+  public static final String TNS_ALIAS = "tnsAlias";
+
+  /**
+   *  Optional password used to decrypt the wallet (for PKCS12 or encrypted PEM).
+   */
+  public static final String WALLET_PASSWORD = "walletPassword";
+
+  /**
+   *  Index of the credential set in the wallet
+   */
+  public static final String CONNECTION_STRING_INDEX = "connectionStringIndex";
+
+  /**
+   *  The wallet/file format: SSO, PKCS12, or PEM.
+   */
+  public static final String TYPE = "type";
+
+  // Parameter Store specific
+  /**
+   *  The name of the parameter stored in AWS Parameter Store.
+   */
+  public static final String PARAMETER_NAME = "parameterName";
+
+  // Secrets Manager specific
+  /**
+   *  The name of the secret stored in AWS Secrets Manager.
+   */
+  public static final String SECRET_NAME = "secretName";
+
+  /**
+   *  Optional field name to extract from a JSON secret.
+   */
+  public static final String FIELD_NAME = "fieldName";
 }

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/AwsResourceProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/AwsResourceProvider.java
@@ -48,7 +48,7 @@ import java.util.stream.Stream;
 import static oracle.jdbc.provider.aws.authentication.AwsAuthenticationMethod.DEFAULT;
 import static oracle.jdbc.provider.aws.authentication.AwsCredentialsFactory.AUTHENTICATION_METHOD;
 import static oracle.jdbc.provider.aws.configuration.AwsConfigurationParameters.REGION;
-import static oracle.jdbc.provider.aws.resource.AwsSecretsManagerResourceParameterNames.AWS_REGION;
+import static oracle.jdbc.provider.aws.resource.AwsResourceParameterNames.AWS_REGION;
 
 /**
  * Super class of all {@code OracleResourceProvider} implementations

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/ParameterStoreConnectionStringProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/ParameterStoreConnectionStringProvider.java
@@ -43,8 +43,8 @@ import oracle.jdbc.provider.resource.ResourceParameter;
 import oracle.jdbc.provider.util.TNSNames;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 
 import static oracle.jdbc.provider.util.CommonParameters.TNS_ALIAS;
@@ -53,49 +53,43 @@ import static oracle.jdbc.provider.util.FileUtils.decodeIfBase64;
 /**
  * <p>
  * A provider for securely retrieving the connection string from a tnsnames.ora
- * file stored in AWS Secrets Manager for use with an Oracle Autonomous Database.
- * The tnsnames.ora file is stored as a base64-encoded or plain-text secret in
- * AWS Secrets Manager, and is decoded and parsed to select connection string
- * based on specified alias.
+ * file stored in AWS Parameter Store for use with an Oracle Autonomous Database.
+ * The tnsnames.ora file is stored as a base64-encoded or plain-text parameter,
+ * and is decoded and parsed to select a connection string based on the specified alias.
  * </p>
  * <p>
  * This class implements the {@link ConnectionStringProvider} SPI defined by
  * Oracle JDBC. It is designed to be instantiated via {@link java.util.ServiceLoader}.
  * </p>
  */
-public class SecretsManagerConnectionStringProvider
-  extends SecretsManagerSecretProvider
-  implements ConnectionStringProvider {
+public class ParameterStoreConnectionStringProvider
+        extends ParameterStoreSecretProvider
+        implements ConnectionStringProvider {
 
   private static final ResourceParameter[] PARAMETERS = {
-    new ResourceParameter(AwsResourceParameterNames.TNS_ALIAS,
-      TNS_ALIAS)
+          new ResourceParameter(AwsResourceParameterNames.TNS_ALIAS, TNS_ALIAS)
   };
 
-  /**
-   * A public no-arg constructor used by {@link java.util.ServiceLoader} to
-   * construct an instance of this provider.
-   */
-  public SecretsManagerConnectionStringProvider() {
-    super("secrets-manager-tnsnames", PARAMETERS);
+  public ParameterStoreConnectionStringProvider() {
+    super("parameter-store-tnsnames", PARAMETERS);
   }
 
   /**
    * Retrieves a database connection string from the tnsnames.ora file stored
-   * in AWS Secrets Manager.
+   * in AWS Parameter Store.
    * <p>
-   * This method accesses the file stored as a secret in AWS Secrets Manager,
+   * This method accesses the file stored as a parameter in AWS Parameter Store,
    * attempts to decode it if it is base64-encoded, and then parses the
    * tnsnames.ora content. It returns the connection string associated with
    * the specified alias from the tnsnames.ora file.
    * </p>
    *
    * @param parameterValues The parameters required to access the tnsnames.ora
-   * file in AWS Secrets Manager, including the secret name and the tnsAlias.
+   * file in AWS Parameter Store, including the parameter name and the tnsAlias.
    * @return The connection string associated with the specified alias
    * in the tnsnames.ora file.
    * @throws IllegalStateException If there is an error reading the tnsnames.ora
-   * file or accessing AWS Secrets Manager.
+   * file or accessing AWS Parameter Store.
    * @throws IllegalArgumentException If the specified alias is invalid or
    * does not exist in the tnsnames.ora file.
    */
@@ -115,5 +109,4 @@ public class SecretsManagerConnectionStringProvider
       throw new IllegalStateException("Failed to read tnsnames.ora content", e);
     }
   }
-
 }

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/ParameterStorePasswordProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/ParameterStorePasswordProvider.java
@@ -35,25 +35,44 @@
  ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  ** SOFTWARE.
  */
-package oracle.provider.aws;
 
-public enum AwsTestProperty {
-  AWS_S3_URL,
-  AWS_SECRETS_MANAGER_URL,
-  AWS_APP_CONFIG_URL,
-  AWS_REGION,
-  DB_CREDENTIALS_SECRET_NAME,
-  TNSNAMES_SECRET_NAME,
-  TNS_ALIAS,
-  PKCS12_WALLET_SECRET_NAME,
-  WALLET_PASSWORD,
-  SSO_WALLET_SECRET_NAME,
-  PEM_WALLET_SECRET_NAME,
-  PKCS12_SEPS_WALLET_SECRET_NAME,
-  SSO_SEPS_WALLET_SECRET_NAME,
-  AWS_PARAMETER_STORE_URL,
-  AWS_PARAMETER_STORE_PASSWORD_NAME,
-  AWS_PARAMETER_STORE_TNSNAMES_NAME,
-  PKCS12_SEPS_WALLET_PARAMETER_NAME,
-  SSO_SEPS_WALLET_PARAMETER_NAME
+package oracle.jdbc.provider.aws.resource;
+
+import oracle.jdbc.spi.PasswordProvider;
+
+import java.util.Map;
+
+/**
+ * <p>
+ * A provider of password managed as parameters in AWS Systems Manager Parameter Store.
+ * This class inherits parameters and behavior from {@link ParameterStoreSecretProvider}
+ * and {@link AwsResourceProvider}.
+ * </p><p>
+ * This class implements the {@link PasswordProvider} SPI defined by Oracle JDBC.
+ * It is designed to be located and instantiated by {@link java.util.ServiceLoader}.
+ * </p>
+ */
+public class ParameterStorePasswordProvider
+  extends ParameterStoreSecretProvider
+  implements PasswordProvider {
+
+  /**
+   * A public no-arg constructor used by {@link java.util.ServiceLoader}
+   * to construct an instance of this provider.
+   */
+  public ParameterStorePasswordProvider() {
+    super("parameter-store-password");
+  }
+
+  /**
+   * Retrieves a password stored in AWS Parameter Store.
+   *
+   * @param parameterValues A map of parameter names and values required for
+   * retrieving the parameter. Must not be null.
+   * @return The secret value as a char array. Not null.
+   */
+  @Override
+  public char[] getPassword(Map<Parameter, CharSequence> parameterValues) {
+    return getSecret(parameterValues).toCharArray();
+  }
 }

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/ParameterStoreSecretProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/ParameterStoreSecretProvider.java
@@ -38,31 +38,48 @@
 
 package oracle.jdbc.provider.aws.resource;
 
+import oracle.jdbc.provider.aws.parameterstore.ParameterStoreFactory;
+import oracle.jdbc.provider.resource.ResourceParameter;
+import oracle.jdbc.provider.util.ResourceParameterUtils;
+
+import java.util.Map;
+
+import static oracle.jdbc.provider.aws.resource.AwsResourceParameterNames.PARAMETER_NAME;
+
 /**
- * Centralized parameter name constants used by AWS Secrets Manager resource providers.
+ * <p>
+ * Base class for all providers that retrieve secrets from AWS Parameter Store.
+ * This class defines shared parameters and secret retrieval logic.
+ * </p>
  */
-public final class AwsSecretsManagerResourceParameterNames {
+public abstract class ParameterStoreSecretProvider extends AwsResourceProvider {
 
-  private AwsSecretsManagerResourceParameterNames() {}
+  private static final ResourceParameter[] PARAMETERS = {
+    new ResourceParameter(PARAMETER_NAME, ParameterStoreFactory.PARAMETER_NAME)
+  };
 
-  /** The AWS region where the secret is located (e.g., eu-north-1). */
-  public static final String AWS_REGION = "awsRegion";
+  protected ParameterStoreSecretProvider(String resourceType) {
+    super(resourceType, PARAMETERS);
+  }
 
-  /** The name of the secret stored in AWS Secrets Manager. */
-  public static final String SECRET_NAME = "secretName";
+  protected ParameterStoreSecretProvider(String resourceType, ResourceParameter[] additionalParameters) {
+    super(resourceType, ResourceParameterUtils.combineParameters(PARAMETERS, additionalParameters));
+  }
 
-  /** Optional field name to extract from a JSON secret. */
-  public static final String FIELD_NAME = "fieldName";
-
-  /** The alias used to retrieve a connection string from tnsnames.ora. */
-  public static final String TNS_ALIAS = "tnsAlias";
-
-  /** Optional password used to decrypt the wallet (for PKCS12 or encrypted PEM). */
-  public static final String WALLET_PASSWORD = "walletPassword";
-
-  /** The wallet format: SSO, PKCS12, or PEM. */
-  public static final String TYPE = "type";
-
-  /** Index of the credential set in the wallet */
-  public static final String CONNECTION_STRING_INDEX = "connectionStringIndex";
+  /**
+   * <p>
+   * Retrieves a secret from AWS Parameter Store based on parameters provided
+   * in {@code parameterValues}. This method centralizes secret retrieval logic
+   * and is intended to be used by subclasses implementing the
+   * {@link oracle.jdbc.spi.OracleResourceProvider} SPI.
+   * </p>
+   *
+   * @param parameterValues A map of parameter names and their corresponding
+   * values required for secret retrieval.
+   * @return The secret value as a {@code String}.
+   * @throws IllegalStateException If secret retrieval fails or returns null.
+   */
+  protected final String getSecret(Map<Parameter, CharSequence> parameterValues) {
+    return getResource(ParameterStoreFactory.getInstance(), parameterValues);
+  }
 }

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/ParameterStoreUsernameProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/ParameterStoreUsernameProvider.java
@@ -35,25 +35,44 @@
  ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  ** SOFTWARE.
  */
-package oracle.provider.aws;
 
-public enum AwsTestProperty {
-  AWS_S3_URL,
-  AWS_SECRETS_MANAGER_URL,
-  AWS_APP_CONFIG_URL,
-  AWS_REGION,
-  DB_CREDENTIALS_SECRET_NAME,
-  TNSNAMES_SECRET_NAME,
-  TNS_ALIAS,
-  PKCS12_WALLET_SECRET_NAME,
-  WALLET_PASSWORD,
-  SSO_WALLET_SECRET_NAME,
-  PEM_WALLET_SECRET_NAME,
-  PKCS12_SEPS_WALLET_SECRET_NAME,
-  SSO_SEPS_WALLET_SECRET_NAME,
-  AWS_PARAMETER_STORE_URL,
-  AWS_PARAMETER_STORE_PASSWORD_NAME,
-  AWS_PARAMETER_STORE_TNSNAMES_NAME,
-  PKCS12_SEPS_WALLET_PARAMETER_NAME,
-  SSO_SEPS_WALLET_PARAMETER_NAME
+package oracle.jdbc.provider.aws.resource;
+
+import oracle.jdbc.spi.UsernameProvider;
+
+import java.util.Map;
+
+/**
+ * <p>
+ * A provider of username managed as parameters in AWS Systems Manager Parameter Store.
+ * This class inherits parameters and behavior from {@link ParameterStoreSecretProvider}
+ * and {@link AwsResourceProvider}.
+ * </p><p>
+ * This class implements the {@link UsernameProvider} SPI defined by Oracle JDBC.
+ * It is designed to be located and instantiated by {@link java.util.ServiceLoader}.
+ * </p>
+ */
+public class ParameterStoreUsernameProvider
+  extends ParameterStoreSecretProvider
+  implements UsernameProvider {
+
+  /**
+   * A public no-arg constructor used by {@link java.util.ServiceLoader}
+   * to construct an instance of this provider.
+   */
+  public ParameterStoreUsernameProvider() {
+    super("parameter-store-username");
+  }
+
+  /**
+   * Retrieves a username stored in AWS Parameter Store.
+   *
+   * @param parameterValues A map of parameter names and values required for
+   * retrieving the parameter. Must not be null.
+   * @return The secret value as the database username. Not null.
+   */
+  @Override
+  public String getUsername(Map<Parameter, CharSequence> parameterValues) {
+    return getSecret(parameterValues);
+  }
 }

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/SecretsManagerSecretProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/SecretsManagerSecretProvider.java
@@ -58,9 +58,9 @@ import static oracle.jdbc.provider.aws.secrets.SecretsManagerFactory.SECRET_NAME
 public class SecretsManagerSecretProvider extends AwsResourceProvider {
 
   private static final ResourceParameter[] PARAMETERS = {
-    new ResourceParameter(AwsSecretsManagerResourceParameterNames.SECRET_NAME,
+    new ResourceParameter(AwsResourceParameterNames.SECRET_NAME,
       SECRET_NAME),
-    new ResourceParameter(AwsSecretsManagerResourceParameterNames.FIELD_NAME,
+    new ResourceParameter(AwsResourceParameterNames.FIELD_NAME,
       FIELD_NAME)
   };
 
@@ -94,7 +94,7 @@ public class SecretsManagerSecretProvider extends AwsResourceProvider {
     String secretJson = getResource(SecretsManagerFactory.getInstance(),
       parameterValues);
     ResourceParameter fieldNameParam = Stream.of(PARAMETERS)
-      .filter(param -> param.name().equals(AwsSecretsManagerResourceParameterNames.FIELD_NAME))
+      .filter(param -> param.name().equals(AwsResourceParameterNames.FIELD_NAME))
       .findFirst()
       .orElse(null);
     String fieldName = parameterValues.containsKey(fieldNameParam) ?

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/SecretsManagerTCPSProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/SecretsManagerTCPSProvider.java
@@ -74,9 +74,9 @@ public class SecretsManagerTCPSProvider
   implements TlsConfigurationProvider {
 
   private static final ResourceParameter[] PARAMETERS = {
-    new ResourceParameter(AwsSecretsManagerResourceParameterNames.WALLET_PASSWORD,
+    new ResourceParameter(AwsResourceParameterNames.WALLET_PASSWORD,
       PASSWORD),
-    new ResourceParameter(AwsSecretsManagerResourceParameterNames.TYPE, TYPE)
+    new ResourceParameter(AwsResourceParameterNames.TYPE, TYPE)
   };
 
   /**

--- a/ojdbc-provider-aws/src/main/resources/META-INF/services/oracle.jdbc.spi.ConnectionStringProvider
+++ b/ojdbc-provider-aws/src/main/resources/META-INF/services/oracle.jdbc.spi.ConnectionStringProvider
@@ -1,1 +1,2 @@
 oracle.jdbc.provider.aws.resource.SecretsManagerConnectionStringProvider
+oracle.jdbc.provider.aws.resource.ParameterStoreConnectionStringProvider

--- a/ojdbc-provider-aws/src/main/resources/META-INF/services/oracle.jdbc.spi.PasswordProvider
+++ b/ojdbc-provider-aws/src/main/resources/META-INF/services/oracle.jdbc.spi.PasswordProvider
@@ -1,2 +1,4 @@
 oracle.jdbc.provider.aws.resource.SecretsManagerPasswordProvider
+oracle.jdbc.provider.aws.resource.ParameterStorePasswordProvider
 oracle.jdbc.provider.aws.resource.SecretsManagerSEPSProvider
+oracle.jdbc.provider.aws.resource.ParameterStoreSEPSProvider

--- a/ojdbc-provider-aws/src/main/resources/META-INF/services/oracle.jdbc.spi.UsernameProvider
+++ b/ojdbc-provider-aws/src/main/resources/META-INF/services/oracle.jdbc.spi.UsernameProvider
@@ -1,2 +1,4 @@
 oracle.jdbc.provider.aws.resource.SecretsManagerUsernameProvider
+oracle.jdbc.provider.aws.resource.ParameterStoreUsernameProvider
 oracle.jdbc.provider.aws.resource.SecretsManagerSEPSProvider
+oracle.jdbc.provider.aws.resource.ParameterStoreSEPSProvider

--- a/ojdbc-provider-aws/src/test/java/oracle/provider/aws/resource/ParameterStoreConnectionStringProviderTest.java
+++ b/ojdbc-provider-aws/src/test/java/oracle/provider/aws/resource/ParameterStoreConnectionStringProviderTest.java
@@ -1,0 +1,117 @@
+/*
+ ** Copyright (c) 2025 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.provider.aws.resource;
+
+import oracle.jdbc.provider.TestProperties;
+import oracle.jdbc.spi.ConnectionStringProvider;
+import oracle.jdbc.spi.OracleResourceProvider.Parameter;
+import oracle.provider.aws.AwsTestProperty;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.createParameterValues;
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.findProvider;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ParameterStoreConnectionStringProviderTest {
+  private static final ConnectionStringProvider PROVIDER =
+          findProvider(ConnectionStringProvider.class, "ojdbc-provider-aws-parameter-store-tnsnames");
+
+  @Test
+  public void testGetParameters() {
+    Collection<? extends Parameter> parameters = PROVIDER.getParameters();
+    assertNotNull(parameters);
+
+    Parameter secretName = parameters.stream()
+            .filter(p -> "parameterName".equals(p.name()))
+            .findFirst().orElseThrow(AssertionError::new);
+    assertFalse(secretName.isSensitive());
+    assertTrue(secretName.isRequired());
+    assertNull(secretName.defaultValue());
+
+    Parameter tnsAlias = parameters.stream()
+            .filter(p -> "tnsAlias".equals(p.name()))
+            .findFirst().orElseThrow(AssertionError::new);
+    assertTrue(tnsAlias.isSensitive());
+    assertTrue(tnsAlias.isRequired());
+    assertNull(tnsAlias.defaultValue());
+
+    Parameter regionParam = parameters.stream()
+            .filter(p -> "awsRegion".equals(p.name()))
+            .findFirst().orElseThrow(AssertionError::new);
+    assertFalse(regionParam.isSensitive());
+    assertFalse(regionParam.isRequired());
+    assertNull(regionParam.defaultValue());
+  }
+
+  @Test
+  public void testValidAlias() {
+    Map<String, String> testParameters = new HashMap<>();
+    testParameters.put("parameterName",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_PARAMETER_STORE_TNSNAMES_NAME));
+    testParameters.put("tnsAlias",
+      TestProperties.getOrAbort(AwsTestProperty.TNS_ALIAS));
+    testParameters.put("awsRegion",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_REGION));
+
+    Map<Parameter, CharSequence> parameterValues =
+      createParameterValues(PROVIDER, testParameters);
+
+    assertNotNull(PROVIDER.getConnectionString(parameterValues));
+  }
+
+  @Test
+  public void testInvalidAlias() {
+    Map<String, String> testParameters = new HashMap<>();
+    testParameters.put("parameterName",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_PARAMETER_STORE_TNSNAMES_NAME));
+    testParameters.put("tnsAlias", "DOES_NOT_EXIST");
+    testParameters.put("awsRegion",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_REGION));
+
+    Map<Parameter, CharSequence> parameterValues =
+      createParameterValues(PROVIDER, testParameters);
+
+    assertThrows(IllegalArgumentException.class, () ->
+      PROVIDER.getConnectionString(parameterValues));
+  }
+}

--- a/ojdbc-provider-aws/src/test/java/oracle/provider/aws/resource/ParameterStorePasswordProviderTest.java
+++ b/ojdbc-provider-aws/src/test/java/oracle/provider/aws/resource/ParameterStorePasswordProviderTest.java
@@ -1,0 +1,93 @@
+/*
+ ** Copyright (c) 2025 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.provider.aws.resource;
+
+import oracle.jdbc.provider.TestProperties;
+import oracle.jdbc.spi.OracleResourceProvider.Parameter;
+import oracle.jdbc.spi.PasswordProvider;
+import oracle.provider.aws.AwsTestProperty;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.createParameterValues;
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.findProvider;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ParameterStorePasswordProviderTest {
+
+  private static final PasswordProvider PROVIDER =
+          findProvider(PasswordProvider.class, "ojdbc-provider-aws-parameter-store-password");
+
+  @Test
+  public void testGetParameters() {
+    Collection<? extends Parameter> parameters = PROVIDER.getParameters();
+    assertNotNull(parameters);
+
+    Parameter secretName = parameters.stream()
+            .filter(p -> "parameterName".equals(p.name()))
+            .findFirst().orElseThrow(AssertionError::new);
+    assertFalse(secretName.isSensitive());
+    assertTrue(secretName.isRequired());
+    assertNull(secretName.defaultValue());
+
+    Parameter regionParameter = parameters.stream()
+            .filter(parameter -> "awsRegion".equals(parameter.name()))
+            .findFirst()
+            .orElseThrow(AssertionError::new);
+    assertFalse(regionParameter.isSensitive());
+    assertFalse(regionParameter.isRequired());
+    assertNull(regionParameter.defaultValue());
+  }
+
+  @Test
+  public void testGetPassword() {
+    Map<String, String> testParameters = new HashMap<>();
+    testParameters.put("parameterName",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_PARAMETER_STORE_PASSWORD_NAME));
+    testParameters.put("awsRegion",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_REGION));
+    Map<Parameter, CharSequence> parameterValues =
+      createParameterValues(PROVIDER, testParameters);
+
+    assertNotNull(PROVIDER.getPassword(parameterValues));
+  }
+}

--- a/ojdbc-provider-aws/src/test/java/oracle/provider/aws/resource/ParameterStoreSepsProviderTest.java
+++ b/ojdbc-provider-aws/src/test/java/oracle/provider/aws/resource/ParameterStoreSepsProviderTest.java
@@ -1,0 +1,166 @@
+/*
+ ** Copyright (c) 2025 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.provider.aws.resource;
+
+import oracle.jdbc.provider.TestProperties;
+import oracle.jdbc.spi.OracleResourceProvider.Parameter;
+import oracle.jdbc.spi.PasswordProvider;
+import oracle.jdbc.spi.UsernameProvider;
+import oracle.provider.aws.AwsTestProperty;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.createParameterValues;
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.findProvider;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ParameterStoreSepsProviderTest {
+
+  private static final UsernameProvider USERNAME_PROVIDER =
+    findProvider(UsernameProvider.class, "ojdbc-provider-aws-parameter-store-seps");
+
+  private static final PasswordProvider PASSWORD_PROVIDER =
+    findProvider(PasswordProvider.class, "ojdbc-provider-aws-parameter-store-seps");
+
+  @Test
+  public void testGetParameters() {
+    Collection<? extends Parameter> usernameParams = USERNAME_PROVIDER.getParameters();
+    Collection<? extends Parameter> passwordParams = PASSWORD_PROVIDER.getParameters();
+
+    assertEquals(usernameParams, passwordParams, "Username and Password providers should expose same parameters");
+
+    assertNotNull(usernameParams);
+    assertNotNull(passwordParams);
+
+    Parameter paramName = usernameParams.stream()
+            .filter(p -> "parameterName".equals(p.name()))
+            .findFirst().orElseThrow(AssertionError::new);
+    assertFalse(paramName.isSensitive());
+    assertTrue(paramName.isRequired());
+
+    Parameter walletPassword = usernameParams.stream()
+            .filter(p -> "walletPassword".equals(p.name()))
+            .findFirst().orElseThrow(AssertionError::new);
+    assertTrue(walletPassword.isSensitive());
+    assertFalse(walletPassword.isRequired());
+
+    Parameter connIndex = usernameParams.stream()
+            .filter(p -> "connectionStringIndex".equals(p.name()))
+            .findFirst().orElseThrow(AssertionError::new);
+    assertFalse(connIndex.isSensitive());
+    assertFalse(connIndex.isRequired());
+
+    Parameter awsRegion = usernameParams.stream()
+            .filter(p -> "awsRegion".equals(p.name()))
+            .findFirst().orElseThrow(AssertionError::new);
+    assertFalse(awsRegion.isSensitive());
+    assertFalse(awsRegion.isRequired());
+  }
+
+  @Test
+  public void testPkcs12PasswordWithIndex() {
+    Map<String, String> params = new HashMap<>();
+    params.put("parameterName",
+      TestProperties.getOrAbort(AwsTestProperty.PKCS12_SEPS_WALLET_PARAMETER_NAME));
+    params.put("walletPassword",
+      TestProperties.getOrAbort(AwsTestProperty.WALLET_PASSWORD));
+    params.put("connectionStringIndex", "1");
+    params.put("awsRegion",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_REGION));
+
+    Map<Parameter, CharSequence> values = createParameterValues(PASSWORD_PROVIDER, params);
+    assertNotNull(PASSWORD_PROVIDER.getPassword(values));
+  }
+
+  @Test
+  public void testPkcs12PasswordWithoutIndex() {
+    Map<String, String> params = new HashMap<>();
+    params.put("parameterName",
+      TestProperties.getOrAbort(AwsTestProperty.PKCS12_SEPS_WALLET_PARAMETER_NAME));
+    params.put("walletPassword",
+      TestProperties.getOrAbort(AwsTestProperty.WALLET_PASSWORD));
+    params.put("awsRegion",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_REGION));
+
+    Map<Parameter, CharSequence> values = createParameterValues(PASSWORD_PROVIDER, params);
+    assertNotNull(PASSWORD_PROVIDER.getPassword(values));
+  }
+
+  @Test
+  public void testSsoUsernameWithoutIndex() {
+    Map<String, String> params = new HashMap<>();
+    params.put("parameterName",
+      TestProperties.getOrAbort(AwsTestProperty.SSO_SEPS_WALLET_PARAMETER_NAME));
+    params.put("awsRegion",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_REGION));
+
+    Map<Parameter, CharSequence> values = createParameterValues(USERNAME_PROVIDER, params);
+    assertNotNull(USERNAME_PROVIDER.getUsername(values));
+  }
+
+  @Test
+  public void testPkcs12UsernameWithIndex() {
+    Map<String, String> params = new HashMap<>();
+    params.put("parameterName",
+      TestProperties.getOrAbort(AwsTestProperty.PKCS12_SEPS_WALLET_PARAMETER_NAME));
+    params.put("walletPassword",
+      TestProperties.getOrAbort(AwsTestProperty.WALLET_PASSWORD));
+    params.put("connectionStringIndex", "1");
+    params.put("awsRegion",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_REGION));
+
+    Map<Parameter, CharSequence> values = createParameterValues(USERNAME_PROVIDER, params);
+    assertNotNull(USERNAME_PROVIDER.getUsername(values));
+  }
+
+  @Test
+  public void testPkcs12MissingPassword() {
+    Map<String, String> params = new HashMap<>();
+    params.put("parameterName",
+      TestProperties.getOrAbort(AwsTestProperty.PKCS12_SEPS_WALLET_PARAMETER_NAME));
+    params.put("awsRegion",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_REGION));
+
+    Map<Parameter, CharSequence> values = createParameterValues(PASSWORD_PROVIDER, params);
+    assertThrows(IllegalStateException.class, () -> PASSWORD_PROVIDER.getPassword(values));
+  }
+}

--- a/ojdbc-provider-aws/src/test/java/oracle/provider/aws/resource/ParameterStoreUsernameProviderTest.java
+++ b/ojdbc-provider-aws/src/test/java/oracle/provider/aws/resource/ParameterStoreUsernameProviderTest.java
@@ -1,0 +1,94 @@
+/*
+ ** Copyright (c) 2025 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.provider.aws.resource;
+
+import oracle.jdbc.provider.TestProperties;
+import oracle.jdbc.spi.OracleResourceProvider.Parameter;
+import oracle.jdbc.spi.UsernameProvider;
+import oracle.provider.aws.AwsTestProperty;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.createParameterValues;
+import static oracle.jdbc.provider.resource.ResourceProviderTestUtil.findProvider;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ParameterStoreUsernameProviderTest {
+
+  private static final UsernameProvider PROVIDER =
+          findProvider(UsernameProvider.class, "ojdbc-provider-aws-parameter-store-username");
+
+  @Test
+  public void testGetParameters() {
+    Collection<? extends Parameter> parameters = PROVIDER.getParameters();
+    assertNotNull(parameters);
+
+    Parameter secretName = parameters.stream()
+            .filter(p -> "parameterName".equals(p.name()))
+            .findFirst().orElseThrow(AssertionError::new);
+    assertFalse(secretName.isSensitive());
+    assertTrue(secretName.isRequired());
+    assertNull(secretName.defaultValue());
+
+    Parameter regionParameter = parameters.stream()
+            .filter(parameter -> "awsRegion".equals(parameter.name()))
+            .findFirst()
+            .orElseThrow(AssertionError::new);
+    assertFalse(regionParameter.isSensitive());
+    assertFalse(regionParameter.isRequired());
+    assertNull(regionParameter.defaultValue());
+  }
+
+  @Test
+  public void testGetPassword() {
+    Map<String, String> testParameters = new HashMap<>();
+    testParameters.put("parameterName",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_PARAMETER_STORE_PASSWORD_NAME));
+    testParameters.put("awsRegion",
+      TestProperties.getOrAbort(AwsTestProperty.AWS_REGION));
+
+    Map<Parameter, CharSequence> parameterValues =
+      createParameterValues(PROVIDER, testParameters);
+
+    assertNotNull(PROVIDER.getUsername(parameterValues));
+  }
+}

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws/resource/SimpleParameterStoreConnectionStringProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws/resource/SimpleParameterStoreConnectionStringProviderExample.java
@@ -47,33 +47,38 @@ import java.sql.Statement;
 import java.util.Properties;
 
 /**
- * Example demonstrating how to use the AWS Secrets Manager Password Provider
- * with Oracle JDBC to securely retrieve a database password from AWS Secrets Manager.
+ * Example demonstrating how to configure Oracle JDBC with the AWS Parameter Store
+ * Connection String Provider to retrieve connection strings from a tnsnames.ora
+ * file stored in AWS Parameter Store.
  */
-public class SimplePasswordProviderExample {
-  private static final String DB_URL = "(description=(retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=your_db_host))(connect_data=(service_name=your_service_name))(security=(ssl_server_dn_match=yes)))";
-  private static final String JDBC_URL = "jdbc:oracle:thin:@" + DB_URL;
-
+public class SimpleParameterStoreConnectionStringProviderExample {
   public static void main(String[] args) throws SQLException {
     try {
       OracleDataSource ds = new OracleDataSource();
-      ds.setURL(JDBC_URL);
-      ds.setUser("DB_USER");
+      ds.setURL("jdbc:oracle:thin:@");
+      ds.setUser("DB_USERNAME");
+      ds.setPassword("DB_PASSWORD");
 
       Properties connectionProps = new Properties();
-      connectionProps.put("oracle.jdbc.provider.password", "ojdbc-provider-aws-secrets-manager-password");
-      connectionProps.put("oracle.jdbc.provider.password.secretName", "secret-name");
-      connectionProps.put("oracle.jdbc.provider.password.fieldName", "password");
+
+      // Connection String Provider for retrieving tnsnames.ora content
+      // from AWS Parameter Store
+      connectionProps.put("oracle.jdbc.provider.connectionString",
+        "ojdbc-provider-aws-parameter-store-tnsnames");
+      connectionProps.put("oracle.jdbc.provider.connectionString.parameterName",
+        "parameter-name");
+      connectionProps.put("oracle.jdbc.provider.connectionString.tnsAlias",
+        "tns-alias");
 
       ds.setConnectionProperties(connectionProps);
 
       try (Connection cn = ds.getConnection()) {
-        String connectionString = cn.getMetaData().getURL();
-        System.out.println("Connected to: " + connectionString);
-        Statement st = cn.createStatement();
-        ResultSet rs = st.executeQuery("SELECT 'Hello, db' FROM sys.dual");
-        if (rs.next()) {
-          System.out.println(rs.getString(1));
+        String query = "SELECT 'Hello, db' FROM sys.dual";
+        try (Statement st = cn.createStatement();
+             ResultSet rs = st.executeQuery(query)) {
+          if (rs.next()) {
+            System.out.println(rs.getString(1));
+          }
         }
       }
     } catch (SQLException e) {

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws/resource/SimpleParameterStorePasswordProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws/resource/SimpleParameterStorePasswordProviderExample.java
@@ -1,0 +1,83 @@
+/*
+ ** Copyright (c) 2025 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.jdbc.provider.aws.resource;
+
+import oracle.jdbc.datasource.impl.OracleDataSource;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * Example demonstrating how to use the AWS Parameter Store Password Provider
+ * with Oracle JDBC to securely retrieve a database password from
+ * AWS Parameter Store.
+ */
+public class SimpleParameterStorePasswordProviderExample {
+  private static final String DB_URL = "(description=(retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=your_db_host))(connect_data=(service_name=your_service_name))(security=(ssl_server_dn_match=yes)))";
+  private static final String JDBC_URL = "jdbc:oracle:thin:@" + DB_URL;
+
+  public static void main(String[] args) throws SQLException {
+    try {
+      OracleDataSource ds = new OracleDataSource();
+      ds.setURL(JDBC_URL);
+      ds.setUser("DB_USER");
+
+      Properties connectionProps = new Properties();
+      connectionProps.put("oracle.jdbc.provider.password", "ojdbc-provider-aws-parameter-store-password");
+      connectionProps.put("oracle.jdbc.provider.password.parameterName", "parameter-name");
+
+      ds.setConnectionProperties(connectionProps);
+
+      try (Connection cn = ds.getConnection()) {
+        String connectionString = cn.getMetaData().getURL();
+        System.out.println("Connected to: " + connectionString);
+        Statement st = cn.createStatement();
+        ResultSet rs = st.executeQuery("SELECT 'Hello, db' FROM sys.dual");
+        if (rs.next()) {
+          System.out.println(rs.getString(1));
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException("Connection failed: ", e);
+    }
+  }
+}

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws/resource/SimpleParameterStoreSEPSWalletProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws/resource/SimpleParameterStoreSEPSWalletProviderExample.java
@@ -1,0 +1,84 @@
+/*
+ ** Copyright (c) 2025 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.jdbc.provider.aws.resource;
+
+import oracle.jdbc.datasource.impl.OracleDataSource;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * Example demonstrating how to configure Oracle JDBC with the AWS Parameter Store
+ * SEPS Wallet Provider to retrieve database credentials from a Secure External
+ * Password Store (SEPS) wallet stored in AWS Parameter Store.
+ */
+public class SimpleParameterStoreSEPSWalletProviderExample {
+  private static final String DB_URL = "(description=(retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=your_db_host))(connect_data=(service_name=your_service_name))(security=(ssl_server_dn_match=yes)))";
+  private static final String JDBC_URL = "jdbc:oracle:thin:@" + DB_URL;
+
+  public static void main(String[] args) throws SQLException {
+    try {
+      OracleDataSource ds = new OracleDataSource();
+      ds.setURL(JDBC_URL);
+
+      Properties connectionProps = new Properties();
+      connectionProps.put("oracle.jdbc.provider.username", "ojdbc-provider-aws-parameter-store-seps");
+      connectionProps.put("oracle.jdbc.provider.password", "ojdbc-provider-aws-parameter-store-seps");
+      connectionProps.put("oracle.jdbc.provider.username.parameterName", "parameter-name");
+      connectionProps.put("oracle.jdbc.provider.password.parameterName", "parameter-name");
+
+      ds.setConnectionProperties(connectionProps);
+
+      try (Connection cn = ds.getConnection()) {
+        String connectionString = cn.getMetaData().getURL();
+        System.out.println("Connected to: " + connectionString);
+        Statement st = cn.createStatement();
+        ResultSet rs = st.executeQuery("SELECT 'Hello, db' FROM sys.dual");
+        if (rs.next()) {
+          System.out.println(rs.getString(1));
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException("Connection failed: ", e);
+    }
+  }
+}

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws/resource/SimpleParameterStoreUsernameProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws/resource/SimpleParameterStoreUsernameProviderExample.java
@@ -47,29 +47,23 @@ import java.sql.Statement;
 import java.util.Properties;
 
 /**
- * Example demonstrating how to configure Oracle JDBC with the AWS Secrets Manager
- * TCPS Wallet Provider to establish a secure TLS connection using a wallet stored
- * in AWS Secrets Manager.
+ * Example demonstrating how to use the AWS Parameter Store Username Provider
+ * with Oracle JDBC to securely retrieve a database username from
+ * AWS Parameter Store.
  */
-public class SimpleTCPSWalletProviderExample {
+public class SimpleParameterStoreUsernameProviderExample {
   private static final String DB_URL = "(description=(retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=your_db_host))(connect_data=(service_name=your_service_name))(security=(ssl_server_dn_match=yes)))";
   private static final String JDBC_URL = "jdbc:oracle:thin:@" + DB_URL;
-  private static final String USERNAME = "DB_USER";
-  private static final String PASSWORD = "DB_PASSWORD";
 
   public static void main(String[] args) throws SQLException {
     try {
       OracleDataSource ds = new OracleDataSource();
       ds.setURL(JDBC_URL);
-      ds.setUser(USERNAME);
-      ds.setPassword(PASSWORD);
+      ds.setPassword("DB_PASSWORD");
 
       Properties connectionProps = new Properties();
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration",
-        "ojdbc-provider-aws-secrets-manager-tls");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.secretName",
-        "secret-name");
-      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.type", "SSO");
+      connectionProps.put("oracle.jdbc.provider.username", "ojdbc-provider-aws-parameter-store-username");
+      connectionProps.put("oracle.jdbc.provider.username.parameterName", "parameter-name");
 
       ds.setConnectionProperties(connectionProps);
 

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws/resource/SimpleSecretsManagerPasswordProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws/resource/SimpleSecretsManagerPasswordProviderExample.java
@@ -47,10 +47,10 @@ import java.sql.Statement;
 import java.util.Properties;
 
 /**
- * Example demonstrating how to use the AWS Secrets Manager Username Provider
- * with Oracle JDBC to securely retrieve a database username from AWS Secrets Manager.
+ * Example demonstrating how to use the AWS Secrets Manager Password Provider
+ * with Oracle JDBC to securely retrieve a database password from AWS Secrets Manager.
  */
-public class SimpleUsernameProviderExample {
+public class SimpleSecretsManagerPasswordProviderExample {
   private static final String DB_URL = "(description=(retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=your_db_host))(connect_data=(service_name=your_service_name))(security=(ssl_server_dn_match=yes)))";
   private static final String JDBC_URL = "jdbc:oracle:thin:@" + DB_URL;
 
@@ -58,11 +58,12 @@ public class SimpleUsernameProviderExample {
     try {
       OracleDataSource ds = new OracleDataSource();
       ds.setURL(JDBC_URL);
-      ds.setPassword("DB_PASSWORD");
+      ds.setUser("DB_USER");
 
       Properties connectionProps = new Properties();
-      connectionProps.put("oracle.jdbc.provider.username", "ojdbc-provider-aws-secrets-manager-username");
-      connectionProps.put("oracle.jdbc.provider.username.secretName", "secret-name");
+      connectionProps.put("oracle.jdbc.provider.password", "ojdbc-provider-aws-secrets-manager-password");
+      connectionProps.put("oracle.jdbc.provider.password.secretName", "secret-name");
+      connectionProps.put("oracle.jdbc.provider.password.fieldName", "password");
 
       ds.setConnectionProperties(connectionProps);
 

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws/resource/SimpleSecretsManagerSEPSWalletProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws/resource/SimpleSecretsManagerSEPSWalletProviderExample.java
@@ -1,0 +1,84 @@
+/*
+ ** Copyright (c) 2025 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.jdbc.provider.aws.resource;
+
+import oracle.jdbc.datasource.impl.OracleDataSource;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * Example demonstrating how to configure Oracle JDBC with the AWS Secrets Manager
+ * SEPS Wallet Provider to retrieve database credentials from a Secure External
+ * Password Store (SEPS) wallet stored in AWS Secrets Manager.
+ */
+public class SimpleSecretsManagerSEPSWalletProviderExample {
+  private static final String DB_URL = "(description=(retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=your_db_host))(connect_data=(service_name=your_service_name))(security=(ssl_server_dn_match=yes)))";
+  private static final String JDBC_URL = "jdbc:oracle:thin:@" + DB_URL;
+
+  public static void main(String[] args) throws SQLException {
+    try {
+      OracleDataSource ds = new OracleDataSource();
+      ds.setURL(JDBC_URL);
+
+      Properties connectionProps = new Properties();
+      connectionProps.put("oracle.jdbc.provider.username", "ojdbc-provider-aws-secrets-manager-seps");
+      connectionProps.put("oracle.jdbc.provider.password", "ojdbc-provider-aws-secrets-manager-seps");
+      connectionProps.put("oracle.jdbc.provider.username.secretName", "secret-name");
+      connectionProps.put("oracle.jdbc.provider.password.secretName", "secret-name");
+
+      ds.setConnectionProperties(connectionProps);
+
+      try (Connection cn = ds.getConnection()) {
+        String connectionString = cn.getMetaData().getURL();
+        System.out.println("Connected to: " + connectionString);
+        Statement st = cn.createStatement();
+        ResultSet rs = st.executeQuery("SELECT 'Hello, db' FROM sys.dual");
+        if (rs.next()) {
+          System.out.println(rs.getString(1));
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException("Connection failed: ", e);
+    }
+  }
+}

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws/resource/SimpleSecretsManagerTCPSWalletProviderExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws/resource/SimpleSecretsManagerTCPSWalletProviderExample.java
@@ -1,0 +1,89 @@
+/*
+ ** Copyright (c) 2025 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.jdbc.provider.aws.resource;
+
+import oracle.jdbc.datasource.impl.OracleDataSource;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * Example demonstrating how to configure Oracle JDBC with the AWS Secrets Manager
+ * TCPS Wallet Provider to establish a secure TLS connection using a wallet stored
+ * in AWS Secrets Manager.
+ */
+public class SimpleSecretsManagerTCPSWalletProviderExample {
+  private static final String DB_URL = "(description=(retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=your_db_host))(connect_data=(service_name=your_service_name))(security=(ssl_server_dn_match=yes)))";
+  private static final String JDBC_URL = "jdbc:oracle:thin:@" + DB_URL;
+  private static final String USERNAME = "DB_USER";
+  private static final String PASSWORD = "DB_PASSWORD";
+
+  public static void main(String[] args) throws SQLException {
+    try {
+      OracleDataSource ds = new OracleDataSource();
+      ds.setURL(JDBC_URL);
+      ds.setUser(USERNAME);
+      ds.setPassword(PASSWORD);
+
+      Properties connectionProps = new Properties();
+      connectionProps.put("oracle.jdbc.provider.tlsConfiguration",
+        "ojdbc-provider-aws-secrets-manager-tls");
+      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.secretName",
+        "secret-name");
+      connectionProps.put("oracle.jdbc.provider.tlsConfiguration.type", "SSO");
+
+      ds.setConnectionProperties(connectionProps);
+
+      try (Connection cn = ds.getConnection()) {
+        String connectionString = cn.getMetaData().getURL();
+        System.out.println("Connected to: " + connectionString);
+        Statement st = cn.createStatement();
+        ResultSet rs = st.executeQuery("SELECT 'Hello, db' FROM sys.dual");
+        if (rs.next()) {
+          System.out.println(rs.getString(1));
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException("Connection failed: ", e);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for using AWS Parameter Store with Oracle JDBC resource providers:

- `ojdbc-provider-aws-parameter-store-username`
- `ojdbc-provider-aws-parameter-store-password`
- `ojdbc-provider-aws-parameter-store-tnsnames`
- `ojdbc-provider-aws-parameter-store-seps`

Includes:

- Unit tests for all providers
- Sample property files
- Code samples demonstrating how to use each provider
- README documentation with configuration examples

Note: TCPS wallet is not supported due to Parameter Store size limits.