### PR TITLE
Change ojdbc8 scope to provided to prevent transitive dependency conflicts

### DIFF
--- a/ojdbc-provider-azure/pom.xml
+++ b/ojdbc-provider-azure/pom.xml
@@ -31,6 +31,10 @@
       <artifactId>ojdbc-provider-common</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc8</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
     </dependency>

--- a/ojdbc-provider-gcp/pom.xml
+++ b/ojdbc-provider-gcp/pom.xml
@@ -54,12 +54,6 @@
       <type>test-jar</type>
     </dependency>
     <dependency>
-      <groupId>com.oracle.database.jdbc</groupId>
-      <artifactId>ojdbc-provider-common</artifactId>
-      <classifier>tests</classifier>
-      <type>test-jar</type>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>

--- a/ojdbc-provider-hashicorp/pom.xml
+++ b/ojdbc-provider-hashicorp/pom.xml
@@ -19,6 +19,10 @@
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc-provider-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>

--- a/ojdbc-provider-samples/pom.xml
+++ b/ojdbc-provider-samples/pom.xml
@@ -51,6 +51,10 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc8</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.oracle.database.security</groupId>
       <artifactId>oraclepki</artifactId>
       <scope>runtime</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <groupId>com.oracle.database.jdbc</groupId>
         <artifactId>ojdbc8</artifactId>
         <version>${jdbc.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>com.oracle.database.security</groupId>


### PR DESCRIPTION
Changed ojdbc8 scope to `provided` to prevent transitive dependency conflicts. Applications can now choose their own JDBC driver version (ojdbc8/11/17) without our providers forcing a specific version. Removed duplicate test dependency in GCP module.