### PR TITLE
Fix SEPS fallback for empty connectionStringIndex

### DIFF
--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/WalletUtils.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/WalletUtils.java
@@ -114,7 +114,8 @@ public final class WalletUtils {
    * </p>
    * <ol>
    *   <li>
-   *     <strong>If {@code connectionStringIndex} is {@code null}:</strong>
+   *     <strong>If {@code connectionStringIndex} is {@code null}, empty,
+   *     or blank:</strong>
    *     <ul>
    *       <li>
    *         The method first attempts to retrieve credentials using the default
@@ -182,6 +183,11 @@ public final class WalletUtils {
    */
   public static Credentials getCredentials(
     byte[] walletBytes, char[] walletPassword, String connectionStringIndex) {
+
+    // treat blank as missing
+    if (connectionStringIndex != null && connectionStringIndex.trim().isEmpty()) {
+      connectionStringIndex = null;
+    }
 
     OracleWallet wallet = new OracleWallet();
     try {


### PR DESCRIPTION
Treat empty or blank connectionStringIndex as missing, ensuring SEPS providers
fall back to default or single-entry credentials when available.

Fixes: #207 
