### PR TITLE
Force parser=pkl in PklParserTest.java

### DIFF
--- a/ojdbc-provider-pkl/README.md
+++ b/ojdbc-provider-pkl/README.md
@@ -27,16 +27,16 @@ To use the Oracle JDBC Pkl Parser:
 
 1. Prepare a .pkl configuration file (see examples below).
 2. Add this artifact to your application's classpath.
-3. Reference the .pkl file in the JDBC URL.
+3. Reference the .pkl file and the parser type in the JDBC URL.
 
-The parser type is inferred from the file extension. In this case, it’s "pkl".
-If the file name doesn’t include an extension, you can specify the parser explicitly using the parser option.
+The parser type can be specified using the `parser` option. In this case, it’s "parser=pkl". 
+By default, the parser type is "json".
 All other options (like key, label, etc.) follow the same format as other providers.
 
 Example using the file configuration provider:
 
 ```java
-jdbc:oracle:thin:@config-file://{pkl-file-name}[?parser=pkl&key=prefix&label=value&option1=value1&option2=value2...]
+jdbc:oracle:thin:@config-file://{pkl-file-name}?parser=pkl[&key=prefix&label=value&option1=value1&option2=value2...]
 ```
 
 ## Writing .pkl Configuration
@@ -70,7 +70,7 @@ jdbc {
 #### URL (using file provider):
 
 ```java
-jdbc:oracle:thin:@config-file://myJdbcConfig.pkl
+jdbc:oracle:thin:@config-file://myJdbcConfig.pkl?parser=pkl
 ```
 
 ### 2. Using `import`
@@ -103,5 +103,5 @@ config1 = (JdbcConfig) {
 #### URL (using file provider):
 
 ```java
-jdbc:oracle:thin:@config-file://myJdbcConfig.pkl?key=config1
+jdbc:oracle:thin:@config-file://myJdbcConfig.pkl?parser=pkl&key=config1
 ```

--- a/ojdbc-provider-pkl/src/test/java/oracle/jdbc/provider/pkl/configuration/PklParserTest.java
+++ b/ojdbc-provider-pkl/src/test/java/oracle/jdbc/provider/pkl/configuration/PklParserTest.java
@@ -101,7 +101,7 @@ public class PklParserTest {
     final String location =  file.getAbsolutePath();
 
     Properties properties = PROVIDER
-        .getConnectionProperties(location);
+        .getConnectionProperties(location + "?parser=pkl");
 
 
     assertTrue(properties.containsKey("URL"), "Should contain property URL");

--- a/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/pkl/configuration/PklExample.java
+++ b/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/pkl/configuration/PklExample.java
@@ -58,7 +58,7 @@ public class PklExample {
   public static void main(String[] args) throws SQLException {
     // Sample default URL if non present
     if (args.length == 0) {
-      url = "jdbc:oracle:thin:@config-file://myJdbcConfig.pkl";
+      url = "jdbc:oracle:thin:@config-file://myJdbcConfig.pkl?parser=pkl";
     } else {
       url = args[0];
     }


### PR DESCRIPTION
The parser type is no longer fetched from the file extension in ojdbc 23.26.0.0.0. Users need to specify the parser type explicitly in the URL option,e.g. `<jdbc-url>?parser=pkl1`

This also fixes the test that failed after changing the driver to 23.26.0.0.0.