### PR TITLE
reject blank username/password secrets for gcp

### DIFF
--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpSecretManagerPasswordProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpSecretManagerPasswordProvider.java
@@ -63,6 +63,11 @@ public class GcpSecretManagerPasswordProvider extends GcpSecretManagerProvider i
   public char[] getPassword(Map<Parameter, CharSequence> parameterValues) {
     ByteString secret = getSecret(parameterValues);
     String password = secret.toStringUtf8();
+
+    if (password == null || password.trim().isEmpty()) {
+      throw new IllegalArgumentException("Password secret content is blank.");
+    }
+
     return password.toCharArray();
   }
 

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpSecretManagerUsernameProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/resource/GcpSecretManagerUsernameProvider.java
@@ -60,7 +60,12 @@ public class GcpSecretManagerUsernameProvider extends GcpSecretManagerProvider i
 
   @Override
   public String getUsername(Map<Parameter, CharSequence> parameterValues) {
-    return getSecret(parameterValues).toStringUtf8();
+    String username = getSecret(parameterValues).toStringUtf8();
+
+    if (username == null || username.trim().isEmpty()) {
+      throw new IllegalArgumentException("Username secret content is blank");
+    }
+    return username;
   }
 
 }


### PR DESCRIPTION
Fixes #206 

When a GCP Secret Manager secret is empty , the username/password providers now fail fast by throwing an IllegalArgumentException, preventing silent failures.