### PR TITLE
Fix #219: throw on blank AWS username/password secrets

### DIFF
--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/ParameterStorePasswordProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/ParameterStorePasswordProvider.java
@@ -73,6 +73,10 @@ public class ParameterStorePasswordProvider
    */
   @Override
   public char[] getPassword(Map<Parameter, CharSequence> parameterValues) {
-    return getSecret(parameterValues).toCharArray();
+    String password = getSecret(parameterValues);
+    if (password == null || password.trim().isEmpty()) {
+      throw new IllegalArgumentException("Password parameter content is blank.");
+    }
+    return password.toCharArray();
   }
 }

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/ParameterStoreUsernameProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/ParameterStoreUsernameProvider.java
@@ -73,6 +73,10 @@ public class ParameterStoreUsernameProvider
    */
   @Override
   public String getUsername(Map<Parameter, CharSequence> parameterValues) {
-    return getSecret(parameterValues);
+    String username = getSecret(parameterValues);
+    if (username == null || username.trim().isEmpty()) {
+      throw new IllegalArgumentException("Username parameter content is blank.");
+    }
+    return username;
   }
 }

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/SecretsManagerPasswordProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/SecretsManagerPasswordProvider.java
@@ -72,6 +72,10 @@ public class SecretsManagerPasswordProvider
    */
   @Override
   public char[] getPassword(Map<Parameter, CharSequence> parameterValues) {
-    return getSecret(parameterValues).toCharArray();
+    String password = getSecret(parameterValues);
+    if (password == null || password.trim().isEmpty()) {
+      throw new IllegalArgumentException("Password secret content is blank.");
+    }
+    return password.toCharArray();
   }
 }

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/SecretsManagerUsernameProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/SecretsManagerUsernameProvider.java
@@ -72,6 +72,10 @@ public class SecretsManagerUsernameProvider
    */
   @Override
   public String getUsername(Map<Parameter, CharSequence> parameterValues) {
-    return getSecret(parameterValues);
+    String username = getSecret(parameterValues);
+    if (username == null || username.trim().isEmpty()) {
+      throw new IllegalArgumentException("Username secret content is blank.");
+    }
+    return username;
   }
 }


### PR DESCRIPTION
Fixes #219 

AWS username/password providers now fail fast when the resolved secret/parameter value is empty by throwing an `IllegalArgumentException`. This prevents silent failures