### PR TITLE
Improve SEPS wallet error message (fixes #223)

### DIFF
--- a/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/WalletUtils.java
+++ b/ojdbc-provider-common/src/main/java/oracle/jdbc/provider/util/WalletUtils.java
@@ -194,7 +194,11 @@ public final class WalletUtils {
       wallet.setWalletArray(walletBytes, walletPassword);
     }
     catch (IOException ioException) {
-      throw new IllegalStateException("Failed to open wallet", ioException);
+      String message = "Failed to open wallet. The wallet content may be corrupted or incomplete.";
+      if (walletPassword != null) {
+        message += " If a walletPassword is required and was provided, it may be incorrect.";
+      }
+      throw new IllegalStateException(message, ioException);
     }
 
     try {


### PR DESCRIPTION
Fixes #223 

SEPS wallet providers now surface a clearer error when a wallet can’t be opened (e.g., corrupted/incomplete content).