### PR TITLE
Handle invalid or corrupted tnsnames secrets

### DIFF
--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/ParameterStoreConnectionStringProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/ParameterStoreConnectionStringProvider.java
@@ -107,6 +107,10 @@ public class ParameterStoreConnectionStringProvider
       return connectionString;
     } catch (IOException e) {
       throw new IllegalStateException("Failed to read tnsnames.ora content", e);
+    } catch (StringIndexOutOfBoundsException | IllegalStateException parseException) {
+      throw new IllegalStateException(
+        "Invalid or corrupted tnsnames.ora content. Ensure the secret contains valid, complete tnsnames.ora data (base64-encoded or plain text).", parseException
+      );
     }
   }
 }

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/SecretsManagerConnectionStringProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/resource/SecretsManagerConnectionStringProvider.java
@@ -113,6 +113,10 @@ public class SecretsManagerConnectionStringProvider
       return connectionString;
     } catch (IOException e) {
       throw new IllegalStateException("Failed to read tnsnames.ora content", e);
+    } catch (StringIndexOutOfBoundsException | IllegalStateException parseException) {
+      throw new IllegalStateException(
+        "Invalid or corrupted tnsnames.ora content. Ensure the secret contains valid, complete tnsnames.ora data (base64-encoded or plain text).", parseException
+      );
     }
   }
 

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/resource/VaultConnectionStringProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/resource/VaultConnectionStringProvider.java
@@ -119,7 +119,12 @@ public class VaultConnectionStringProvider
     String secretValue = getVaultSecret(parameterValues)
                            .getBase64Secret();
 
-    byte[] fileBytes = Base64.getDecoder().decode(secretValue);
+    byte[] fileBytes;
+    try {
+      fileBytes = Base64.getDecoder().decode(secretValue);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalStateException("Invalid base64 encoding in secret", e);
+    }
 
     TNSNames tnsNames;
     try (InputStream inputStream = new ByteArrayInputStream(fileBytes)) {


### PR DESCRIPTION
Fixes #220, #221, #222 

AWS and OCI tnsnames connection string providers now handle both base64 and plain-text secrets and return clearer errors when the tnsnames.ora content is invalid or incomplete.

This avoids confusing parsing failures and makes configuration issues easier to understand.