### PR TITLE
Concurrent interactive oci auth

### DIFF
--- a/ojdbc-provider-oci/README.md
+++ b/ojdbc-provider-oci/README.md
@@ -257,7 +257,7 @@ in Optional Parameters</td>
   <td>
     <code>OCI_INSTANCE_PRINCIPAL_TIMEOUT</code> <br>
     <i>(Optional)</i> Specifies the maximum time, in seconds, to wait for the instance principal authentication process to complete.<br>
-    The value must be a valid integer (e.g., <code>5</code>, <code>30</code>). Decimal values are not allowed.<br>
+    The value must be a positive integer (e.g., <code>5</code>, <code>30</code>). Decimal values are not allowed.<br>
     <b>Default:</b> <code>5</code> seconds
   </td>
 </tr>
@@ -271,7 +271,14 @@ in Optional Parameters</td>
   <td><b>OCI_INTERACTIVE</b></td>
   <td>Session Token-Based Authentication</td>
   <td>Same as OCI_DEFAULT</td>
-  <td>Same as OCI_DEFAULT</td>
+  <td>
+    <code>OCI_INTERACTIVE_TIMEOUT</code> <br>
+    <i>(Optional)</i> Specifies the maximum time, in minutes, for the user to complete the browser login.
+    After the timeout, the local HTTP server on port <code>8181</code> is released automatically,
+    so a subsequent authentication attempt will not fail with a <code>BindException</code>.<br>
+    The value must be a positive integer. Decimal values are not allowed.<br>
+    <b>Default:</b> <code>5</code> minutes
+  </td>
 </tr>
 </tbody>
 </table>
@@ -813,7 +820,19 @@ common set of parameters.
       <td>instancePrincipalTimeout</td>
       <td>
         Specifies the maximum time, in seconds, to wait for instance principal authentication to complete.<br>
-        The value must be a valid integer (e.g., <code>5</code>, <code>10</code>). Decimal values are not accepted.
+        The value must be a positive integer (e.g., <code>5</code>, <code>10</code>). Decimal values are not accepted.
+      </td>
+      <td>A positive integer</td>
+      <td><code>5</code></td>
+    </tr>
+    <tr>
+      <td>interactiveTimeout</td>
+      <td>
+        Specifies the maximum time, in minutes, for the user to complete the browser login when
+        <code>authenticationMethod=interactive</code> is configured.
+        After the timeout, the local HTTP server on port <code>8181</code> is released automatically,
+        so a subsequent authentication attempt will not fail with a <code>BindException</code>.<br>
+        The value must be a positive integer. Decimal values are not accepted.
       </td>
       <td>A positive integer</td>
       <td><code>5</code></td>
@@ -889,6 +908,10 @@ Cloud Shell
 <dd>
 Authenticate interactively by logging in to a cloud account with your
 default web browser. The browser window is opened automatically.
+A local HTTP server is started on port <code>8181</code> to receive the OAuth2 redirect after login.
+The server is released automatically once the login completes or the <code>interactiveTimeout</code> expires,
+preventing a <code>BindException</code> if authentication is attempted again.
+You may configure the login timeout using the <code>interactiveTimeout</code> parameter.
 </dd>
 <dt>auto-detect</dt>
 <dd>

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/authentication/AuthenticationDetailsFactory.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/authentication/AuthenticationDetailsFactory.java
@@ -116,6 +116,28 @@ public final class AuthenticationDetailsFactory
     Parameter.create();
 
   /**
+   * Default number of minutes to wait for the user to complete the browser
+   * login during interactive authentication. Used when
+   * {@link #INTERACTIVE_TIMEOUT} is not explicitly configured.
+   */
+  public static final int DEFAULT_INTERACTIVE_TIMEOUT_MINUTES = 5;
+
+  /**
+   * Timeout in minutes for interactive (browser-based) authentication.
+   * Controls how long the provider waits for the user to complete the login
+   * in their web browser before giving up.
+   * <p>
+   * When the timeout expires, the local HTTP server on port 8181 is stopped
+   * automatically, releasing the port so that a subsequent authentication
+   * attempt can bind it again.
+   * </p>
+   * Optional – defaults to {@value #DEFAULT_INTERACTIVE_TIMEOUT_MINUTES}
+   * minutes if not explicitly configured.
+   */
+  public static final Parameter<Integer> INTERACTIVE_TIMEOUT =
+    Parameter.create();
+
+  /**
    * <p>
    * An OCI region provided by instances of
    * {@link AbstractAuthenticationDetailsProvider} which implement the

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/authentication/InteractiveAuthentication.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/authentication/InteractiveAuthentication.java
@@ -47,6 +47,7 @@ import oracle.jdbc.provider.util.JsonWebTokenParser;
 import java.awt.*;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -61,6 +62,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -118,6 +121,9 @@ final class InteractiveAuthentication {
 
     Region region = parameterSet.getOptional(AuthenticationDetailsFactory.REGION);
 
+    int timeoutMinutes =
+      parameterSet.getOptional(AuthenticationDetailsFactory.INTERACTIVE_TIMEOUT);
+
     // The OCI CLI listens on port 8181, so this method will do the same. It is
     // believed that the redirect URI of "http://localhost:8181" is registered
     // with the login endpoint of Oracle Cloud, and so it would reject an
@@ -134,8 +140,11 @@ final class InteractiveAuthentication {
       KeyPair keyPair = generateKeyPair();
       openBrowser(region, keyPair.getPublic(), redirectAddress);
 
-      // Wait for the browser login to complete
-      LoginResult loginResult = awaitLogin(loginFuture);
+      // Wait for the browser login to complete, up to the configured timeout.
+      // When the timeout expires the finally block cancels loginFuture, which
+      // triggers the whenComplete callback in acceptRedirect() to stop the
+      // HTTP server and release port 8181.
+      LoginResult loginResult = awaitLogin(loginFuture, timeoutMinutes);
 
       // If a region has not been configured, then extract it from the
       // "issuer_region" claim of the ID token.
@@ -194,6 +203,19 @@ final class InteractiveAuthentication {
     final HttpServer server;
     try {
       server = HttpServer.create(redirectAddress, 0);
+    }
+    catch (BindException bindException) {
+      // Port 8181 is already held — most likely by a previous interactive
+      // authentication session whose browser login was never completed.
+      // The previous server will release the port automatically once its
+      // login timeout expires (default: 5 minutes).
+      throw new IllegalStateException(
+        "OCI interactive authentication failed: port "
+        + redirectAddress.getPort() + " is already in use."
+        + " A previous interactive authentication session may still be"
+        + " running. Please complete the login in your browser, or wait"
+        + " for the previous session to time out and then try again.",
+        bindException);
     }
     catch (IOException ioException) {
       throw new IllegalStateException(
@@ -389,16 +411,32 @@ final class InteractiveAuthentication {
   }
 
   /**
-   * Awaits the completion of a {@code loginFuture}.
+   * Awaits the completion of a {@code loginFuture}, up to
+   * {@code timeoutMinutes}.
+   * <p>
+   * When the timeout expires the {@code IllegalStateException} propagates to
+   * the caller, whose {@code finally} block cancels the future. Cancelling
+   * the future triggers the {@code whenComplete} callback registered in
+   * {@link #acceptRedirect}, which stops the HTTP server and releases port
+   * 8181 so that the next authentication attempt can bind it.
+   * </p>
    * @param loginFuture Future to await. Not null.
+   * @param timeoutMinutes Maximum minutes to wait for the browser login.
    * @return The result that {@code loginFuture} completes with.
-   * @throws IllegalStateException If the current thread is interrupted, or
-   * the timeout expires, or the {@code loginFuture} completes exceptionally.
+   * @throws IllegalStateException If the current thread is interrupted, the
+   * timeout expires, or the {@code loginFuture} completes exceptionally.
    */
   private static LoginResult awaitLogin(
-    CompletableFuture<LoginResult> loginFuture) {
+    CompletableFuture<LoginResult> loginFuture, int timeoutMinutes) {
     try {
-      return loginFuture.get();
+      return loginFuture.get(timeoutMinutes, TimeUnit.MINUTES);
+    }
+    catch (TimeoutException timeoutException) {
+      throw new IllegalStateException(
+        "Interactive OCI authentication timed out after "
+        + timeoutMinutes + " minute(s). The browser login was not completed"
+        + " in time. Port 8181 has been released.",
+        timeoutException);
     }
     catch (InterruptedException interruptedException) {
       throw new IllegalStateException(

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciConfigurationParameters.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciConfigurationParameters.java
@@ -96,14 +96,10 @@ public final class OciConfigurationParameters {
       .addParameter("OCI_REGION", REGION, null, Region::fromRegionCodeOrId)
       .addParameter("OCI_INSTANCE_PRINCIPAL_TIMEOUT", INSTANCE_PRINCIPAL_TIMEOUT,
          5,
-         s -> {
-           try {
-            return Integer.parseInt(s);
-           }catch (NumberFormatException e) {
-              throw new IllegalArgumentException( "Invalid value for " +
-                "OCI_INSTANCE_PRINCIPAL_TIMEOUT: " + s + ". The value must be an integer.");
-           }
-         })
+         s -> parsePositiveInt("OCI_INSTANCE_PRINCIPAL_TIMEOUT", s))
+      .addParameter("OCI_INTERACTIVE_TIMEOUT", INTERACTIVE_TIMEOUT,
+         DEFAULT_INTERACTIVE_TIMEOUT_MINUTES,
+         s -> parsePositiveInt("OCI_INTERACTIVE_TIMEOUT", s))
       .build();
 
   /**
@@ -113,6 +109,24 @@ public final class OciConfigurationParameters {
    */
   public static ParameterSetParser getParser() {
     return PARAMETER_SET_PARSER;
+  }
+
+  /**
+   * Parses {@code s} as a positive integer for the named parameter.
+   * Throws {@link IllegalArgumentException} if the value is not a positive
+   * integer or cannot be parsed.
+   */
+  private static int parsePositiveInt(String paramName, String s) {
+    try {
+      int value = Integer.parseInt(s);
+      if (value <= 0)
+        throw new IllegalArgumentException("Invalid value for " + paramName
+          + ": " + s + ". The value must be a positive integer.");
+      return value;
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid value for " + paramName
+        + ": " + s + ". The value must be a positive integer.");
+    }
   }
 
   /**

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/resource/OciResourceProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/resource/OciResourceProvider.java
@@ -83,14 +83,13 @@ public abstract class OciResourceProvider
       new ResourceParameter("instancePrincipalTimeout",
         AuthenticationDetailsFactory.INSTANCE_PRINCIPAL_TIMEOUT,
         "5",
-          s -> {
-            try {
-              return Integer.parseInt(s);
-            } catch (NumberFormatException e) {
-              throw new IllegalArgumentException("Invalid value for instancePrincipalTimeout: " + s +
-                " – must be an integer.");
-            }
-        }),
+        s -> parsePositiveInt("instancePrincipalTimeout", s)),
+      new ResourceParameter(
+        "interactiveTimeout",
+        AuthenticationDetailsFactory.INTERACTIVE_TIMEOUT,
+        String.valueOf(
+          AuthenticationDetailsFactory.DEFAULT_INTERACTIVE_TIMEOUT_MINUTES),
+        s -> parsePositiveInt("interactiveTimeout", s)),
       new ResourceParameter(
         "region",
         AuthenticationDetailsFactory.REGION,
@@ -122,6 +121,26 @@ public abstract class OciResourceProvider
           Stream.of(PARAMETERS),
           Stream.of(parameters))
         .toArray(ResourceParameter[]::new));
+  }
+
+  /**
+   * Parses {@code s} as a positive integer for the named parameter.
+   * Throws {@link IllegalArgumentException} if the value is not a positive
+   * integer or cannot be parsed.
+   */
+  private static int parsePositiveInt(String paramName, String s) {
+    try {
+      int value = Integer.parseInt(s);
+      if (value <= 0)
+        throw new IllegalArgumentException(
+          "Invalid value for " + paramName + ": " + s
+          + " – must be a positive integer.");
+      return value;
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+        "Invalid value for " + paramName + ": " + s
+        + " – must be a positive integer.");
+    }
   }
 
   /**


### PR DESCRIPTION
This PR fixes issue #76  where concurrent interactive OCI authentication attempts crash with `java.net.BindException: Address already in use `on port 8181. The root cause was `loginFuture.get() `having no timeout, holding the port indefinitely on an incomplete browser login. The fix introduces a 5-minute default timeout so port 8181 is released automatically when the deadline expires. This timeout is configurable via the `interactiveTimeout` parameter (resource providers) or `OCI_INTERACTIVE_TIMEOUT` query parameter (config providers) for users who need a longer or shorter window.
                                                                                                                                                                                   
As part of this change, `instancePrincipalTimeout` and `interactiveTimeout` now share the same `parsePositiveInt` validation logic, and both timeout parameters enforce positive values consistently.