### PR TITLE
 make auth method values case-insensitive for config and resource providers

### DIFF
--- a/ojdbc-provider-oci/README.md
+++ b/ojdbc-provider-oci/README.md
@@ -223,7 +223,7 @@ share the same sets of parameters for authentication configuration.
 
 The Centralized Config Providers in this module use the
 [OCI SDK Authentication Methods](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdk_authentication_methods.htm) to provide authorization and authentication to the Object Storage, Database Tools Connection and Vault services.
-The user can provide an optional parameter `AUTHENTICATION` (case-ignored) which is mapped with the following Credential Class.
+The user can provide an optional parameter `AUTHENTICATION` (case-ignored), and its values are also parsed case-insensitively. It is mapped with the following Credential Class.
 
 <table>
 <thead><tr>
@@ -858,7 +858,7 @@ not supported.
 Providers in this module must authenticate with OCI. By default, a provider will
 automatically detect any available credentials.  A specific credential
 may be configured using the "authenticationMethod" parameter. The parameter may
-be set to any of the following values:
+be set to any of the following values (case-insensitive):
 <dl>
 <dt>config-file</dt>
 <dd>

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciConfigurationParameters.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciConfigurationParameters.java
@@ -44,6 +44,8 @@ import oracle.jdbc.provider.oci.authentication.AuthenticationMethod;
 import oracle.jdbc.provider.parameter.Parameter;
 import oracle.jdbc.provider.parameter.ParameterSetParser;
 
+import java.util.Locale;
+
 import static oracle.jdbc.provider.oci.authentication.AuthenticationDetailsFactory.*;
 import static oracle.jdbc.provider.oci.authentication.AuthenticationMethod.*;
 import static oracle.jdbc.provider.oci.objectstorage.ObjectFactory.OBJECT_URL;
@@ -122,7 +124,7 @@ public final class OciConfigurationParameters {
    */
   private static AuthenticationMethod parseAuthentication(
       String authentication) {
-    switch (authentication) {
+    switch (authentication.toUpperCase(Locale.ROOT)) {
       case "OCI_DEFAULT": return API_KEY;
       case "OCI_INSTANCE_PRINCIPAL": return INSTANCE_PRINCIPAL;
       case "OCI_RESOURCE_PRINCIPAL": return RESOURCE_PRINCIPAL;

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/resource/OciResourceProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/resource/OciResourceProvider.java
@@ -48,6 +48,7 @@ import oracle.jdbc.provider.resource.AbstractResourceProvider;
 import oracle.jdbc.provider.resource.ResourceParameter;
 import oracle.jdbc.provider.util.Wallet;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -129,9 +130,9 @@ public abstract class OciResourceProvider
    * {@link AuthenticationMethod}
    * recognized by the {@link AuthenticationDetailsFactory}.
    */
-  private static AuthenticationMethod parseAuthenticationMethod(
+   static AuthenticationMethod parseAuthenticationMethod(
       String authenticationMethod) {
-    switch (authenticationMethod) {
+    switch (authenticationMethod.toLowerCase(Locale.ROOT)) {
       case "config-file": return CONFIG_FILE;
       case "instance-principal": return INSTANCE_PRINCIPAL;
       case "resource-principal": return RESOURCE_PRINCIPAL;

--- a/ojdbc-provider-oci/src/test/java/oracle/jdbc/provider/oci/configuration/OciConfigurationParametersTest.java
+++ b/ojdbc-provider-oci/src/test/java/oracle/jdbc/provider/oci/configuration/OciConfigurationParametersTest.java
@@ -1,0 +1,109 @@
+/*
+ ** Copyright (c) 2026 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.jdbc.provider.oci.configuration;
+
+import oracle.jdbc.provider.parameter.ParameterSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static oracle.jdbc.provider.oci.authentication.AuthenticationDetailsFactory.AUTHENTICATION_METHOD;
+import static oracle.jdbc.provider.oci.authentication.AuthenticationMethod.API_KEY;
+import static oracle.jdbc.provider.oci.authentication.AuthenticationMethod.INSTANCE_PRINCIPAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies parsing behavior of AUTHENTICATION values in
+ * {@link OciConfigurationParameters}.
+ */
+public class OciConfigurationParametersTest {
+
+  /**
+   * Verifies lowercase AUTHENTICATION values are parsed successfully.
+   */
+  @Test
+  public void testAuthenticationValueLowerCase() {
+    ParameterSet parameterSet = OciConfigurationParameters.getParser()
+      .parseNamedValues(mapOf("AUTHENTICATION", "oci_default"));
+
+    assertEquals(API_KEY, parameterSet.getOptional(AUTHENTICATION_METHOD));
+  }
+
+  /**
+   * Verifies uppercase AUTHENTICATION values are parsed successfully.
+   */
+  @Test
+  public void testAuthenticationValueUpperCase() {
+    ParameterSet parameterSet = OciConfigurationParameters.getParser()
+      .parseNamedValues(mapOf("AUTHENTICATION", "OCI_DEFAULT"));
+
+    assertEquals(API_KEY, parameterSet.getOptional(AUTHENTICATION_METHOD));
+  }
+
+  /**
+   *  Verifies mixed-case AUTHENTICATION values are parsed successfully.
+   */
+  @Test
+  public void testAuthenticationValueMixedCase() {
+    ParameterSet parameterSet = OciConfigurationParameters.getParser()
+      .parseNamedValues(mapOf("AUTHENTICATION", "OCI_instance_principal"));
+
+    assertEquals(INSTANCE_PRINCIPAL, parameterSet.getOptional(AUTHENTICATION_METHOD));
+  }
+
+  /**
+   * Verifies unknown AUTHENTICATION values are rejected.
+   */
+  @Test
+  public void testAuthenticationValueUnknownRejected() {
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> OciConfigurationParameters.getParser()
+        .parseNamedValues(mapOf("AUTHENTICATION", "oci_unknown")));
+  }
+
+  private static Map<String, String> mapOf(String key, String value) {
+    Map<String, String> map = new HashMap<>();
+    map.put(key, value);
+    return Collections.unmodifiableMap(map);
+  }
+}

--- a/ojdbc-provider-oci/src/test/java/oracle/jdbc/provider/oci/resource/OciResourceProviderTest.java
+++ b/ojdbc-provider-oci/src/test/java/oracle/jdbc/provider/oci/resource/OciResourceProviderTest.java
@@ -1,0 +1,91 @@
+/*
+ ** Copyright (c) 2026 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.jdbc.provider.oci.resource;
+
+import oracle.jdbc.provider.oci.authentication.AuthenticationMethod;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies shared authentication parsing behavior in {@link OciResourceProvider}.
+ */
+public class OciResourceProviderTest {
+
+  /**
+   *  Verifies lowercase resource authentication values are parsed.
+   */
+  @Test
+  public void testResourceAuthenticationValueLowerCase() {
+    assertEquals(
+      AuthenticationMethod.CONFIG_FILE,
+      OciResourceProvider.parseAuthenticationMethod("config-file"));
+  }
+
+  /**
+   * Verifies uppercase resource authentication values are parsed.
+   */
+  @Test
+  public void testResourceAuthenticationValueUpperCase() {
+    assertEquals(
+      AuthenticationMethod.CONFIG_FILE,
+      OciResourceProvider.parseAuthenticationMethod("CONFIG-FILE"));
+  }
+
+  /**
+   * Verifies mixed-case resource authentication values are parsed.
+   */
+  @Test
+  public void testResourceAuthenticationValueMixedCase() {
+    assertEquals(
+      AuthenticationMethod.INSTANCE_PRINCIPAL,
+      OciResourceProvider.parseAuthenticationMethod("Instance-PRINCIPAL"));
+  }
+
+  /**
+   * Verifies unknown resource authentication values are rejected.
+   */
+  @Test
+  public void testResourceAuthenticationValueUnknownRejected() {
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> OciResourceProvider.parseAuthenticationMethod("not-a-method"));
+  }
+}


### PR DESCRIPTION
 This PR fixes #247  by making OCI authentication method value parsing case-insensitive across both centralized configuration providers and resource providers. Previously, valid values with lowercase or mixed casing could fail with Unrecognized value, causing parsing to fail before connection setup.

This update normalizes parsing behavior, adds shared unit tests for lowercase/uppercase/mixed-case and unknown values, and updates README wording for both provider types.