### PR TITLE
Enhance DBTools config provider with PEM keystore/truststore support

### DIFF
--- a/ojdbc-provider-oci/pom.xml
+++ b/ojdbc-provider-oci/pom.xml
@@ -18,7 +18,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>3.48.0</version>
+        <version>3.82.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -41,7 +41,6 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-databasetools</artifactId>
-      <version>3.82.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>

--- a/ojdbc-provider-oci/pom.xml
+++ b/ojdbc-provider-oci/pom.xml
@@ -18,7 +18,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>3.82.0</version>
+        <version>3.83.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/ojdbc-provider-oci/pom.xml
+++ b/ojdbc-provider-oci/pom.xml
@@ -41,6 +41,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-databasetools</artifactId>
+      <version>3.82.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
@@ -173,6 +173,9 @@ public class OciDatabaseToolsConnectionProvider
 
         DatabaseToolsKeyStorePassword keyStorePassword =
           keyStore.getKeyStorePassword();
+        String keyStorePasswordValue = keyStorePassword == null
+          ? null
+          : String.valueOf(getSecret(keyStorePassword).toCharArray());
 
         switch (keyStore.getKeyStoreType()) {
         case JavaKeyStore:
@@ -205,6 +208,14 @@ public class OciDatabaseToolsConnectionProvider
           walletProps.put(
             OracleConnection.CONNECTION_PROPERTY_WALLET_LOCATION,
             "data:;base64," + base64KeyStoreContent);
+          break;
+        case Pem:
+          walletProps.put(
+            OracleConnection.CONNECTION_PROPERTY_WALLET_LOCATION,
+            "data:;base64," + base64KeyStoreContent);
+          if (keyStorePasswordValue != null) {
+            walletProps.put("oracle.net.wallet_password", keyStorePasswordValue);
+          }
           break;
         case UnknownEnumValue:
         default:
@@ -323,4 +334,3 @@ public class OciDatabaseToolsConnectionProvider
     }
   }
 }
-


### PR DESCRIPTION
This PR adds support for DBTools connections that use PEM keystore/truststore entries, so PEM-based mTLS material can be consumed consistently with the other supported formats in the OCI DBTools config provider, while keeping existing behavior unchanged.

To enable this feature, the OCI SDK version was updated centrally in the BOM from 3.48.0 to 3.82.0, which includes support for the Pem key store type.

Fixes: #85 