### PR TITLE
Separate the test data of testCachePurged from the original one.

### DIFF
--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/configuration/AzureAppConfigurationProviderTest.java
@@ -3,6 +3,7 @@ package oracle.jdbc.provider.azure.configuration;
 import com.azure.data.appconfiguration.ConfigurationClient;
 import com.azure.data.appconfiguration.ConfigurationClientBuilder;
 import com.azure.data.appconfiguration.models.ConfigurationSetting;
+import com.azure.data.appconfiguration.models.SettingSelector;
 import com.azure.identity.ClientSecretCredentialBuilder;
 import oracle.jdbc.datasource.impl.OracleDataSource;
 import oracle.jdbc.provider.TestProperties;
@@ -13,11 +14,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AzureAppConfigurationProviderTest {
 
@@ -97,7 +96,7 @@ class AzureAppConfigurationProviderTest {
    * correct connect descriptor to connect to Database.
    */
   @Test
-  public void testCachePurged() throws SQLException {
+  public void testCachePurged() {
     ConfigurationClient client = getSecretCredentialClient();
     String APP_CONFIG_NAME=
       TestProperties.getOrAbort(AzureTestProperty.AZURE_APP_CONFIG_NAME);
@@ -106,43 +105,66 @@ class AzureAppConfigurationProviderTest {
     String APP_CONFIG_LABEL =
       TestProperties.getOrAbort(AzureTestProperty.AZURE_APP_CONFIG_LABEL);
 
-    String username = "user";
+    String prefix = "/testCachePurged/";
+    String label = APP_CONFIG_LABEL;
+
+    setupCachePurgeTestData(client, prefix, label, APP_CONFIG_KEY, APP_CONFIG_LABEL);
+
     String originalUrl =
             "jdbc:oracle:thin:@config-azure://" + APP_CONFIG_NAME +
-            "?key=" + APP_CONFIG_KEY + "&label=" + APP_CONFIG_LABEL;
+            "?key=" + prefix + "&label=" + label;
 
     String url = composeUrlWithServicePrincipleAuthentication(originalUrl);
-
-    // Retrieve original value of 'user'
-    String originalKeyValue =
-      client.getConfigurationSetting(APP_CONFIG_KEY + username,
-      APP_CONFIG_LABEL).getValue();
-
-    // Set value of 'user' wrong
-    client.setConfigurationSetting( APP_CONFIG_KEY + username,
-      APP_CONFIG_LABEL, originalKeyValue + "wrong");
 
     try {
       // Connection fails: hit 1017
       SQLException exception = assertThrows(SQLException.class,
         () -> tryConnection(url), "Should throw an SQLException");
-      Assertions.assertEquals(exception.getErrorCode(), 1017);
+      Assertions.assertEquals(1017, exception.getErrorCode(), "Unexpected error message: " + exception.getMessage());
     } finally {
-      // Set value of 'user' correct
-      ConfigurationSetting result =
-        client.setConfigurationSetting(APP_CONFIG_KEY + username,
-          APP_CONFIG_LABEL, originalKeyValue);
-      Assertions.assertEquals(originalKeyValue, result.getValue());
+      cleanupCachePurgeTestData(client, prefix, label);
     }
+  }
 
-    // Connection succeeds
-    try (Connection conn = tryConnection(url)) {
-      Assertions.assertNotNull(conn);
+  /**
+   * Sets up the test data for testCachePurged.
+   * Copies the original configuration and updates the username in the copied
+   * configuration to an invalid value to verify cache purging behavior.
+   */
+  private void setupCachePurgeTestData(
+      ConfigurationClient client,
+      String prefix,
+      String label,
+      String originalPrefix,
+      String originalLabel) {
 
-      Statement st = conn.createStatement();
-      ResultSet rs = st.executeQuery("SELECT 'Hello, db' FROM sys.dual");
-      Assertions.assertNotNull(rs.next());
-      Assertions.assertEquals("Hello, db", rs.getString(1));
+    cleanupCachePurgeTestData(client, prefix, label);
+
+    // Copy the original configuration setting with the new prefix value
+    SettingSelector selector = new SettingSelector();
+    selector.setKeyFilter(originalPrefix + "*");
+    selector.setLabelFilter(originalLabel);
+
+    for (ConfigurationSetting setting : client.listConfigurationSettings(selector)) {
+      String newKey;
+      newKey = setting.getKey().replace(originalPrefix, prefix);
+
+      if (setting.getKey().endsWith("user")) {
+        setting.setValue("wrong_" + setting.getValue());
+      }
+
+      setting.setKey(newKey);
+      client.addConfigurationSetting(setting);
+    }
+  }
+
+  private void cleanupCachePurgeTestData(ConfigurationClient client, String prefix, String label) {
+    SettingSelector selector = new SettingSelector();
+    selector.setKeyFilter(prefix + "*");
+    selector.setLabelFilter(label);
+
+    for (ConfigurationSetting setting : client.listConfigurationSettings(selector)) {
+      client.deleteConfigurationSetting(setting);
     }
   }
 


### PR DESCRIPTION
`oracle.jdbc.provider.azure.configuration.AzureAppConfigurationProviderTest.testCachePurged` has been failing intermittently because of incorrect username/password values.

We should separate the test data used by this test from the other tests to eliminate the interference.