### PR TITLE
Add optional tenantId to Azure interactive auth

### DIFF
--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -219,11 +219,13 @@ The user can provide an optional parameter `AUTHENTICATION` (case-ignored) which
   <td><b>AZURE_CLIENT_ID</b> (only required for user assigned)</td>
 </tr>
 <tr>
-  <td rowspan="2"><b>AZURE_INTERACTIVE</b></td>
-  <td rowspan="2">InteractiveBrowserCredential</td>
-  <td><b>AZURE_CLIENT_ID</b></td>
-  <td><b>AZURE_REDIRECT_URL</b></td>
+  <td rowspan="3"><b>AZURE_INTERACTIVE</b></td>
+  <td rowspan="3">InteractiveBrowserCredential</td>
+  <td rowspan="3">&nbsp;</td>
+  <td><b>AZURE_TENANT_ID</b></td>
 </tr>
+  <tr><td><b>AZURE_CLIENT_ID</b></td></tr>
+  <tr><td><b>AZURE_REDIRECT_URL</b></td></tr>
 </tbody>
 </table>
 
@@ -732,7 +734,7 @@ common set of parameters.
       <a href="https://docs.microsoft.com/en-us/azure/active-directory/develop/reply-url">
       Redirect URL
       </a>
-      for <code>authentication-method=interactive</code>
+      for <code>authenticationMethod=interactive</code>
       </td>
       <td>
       A URL of the form <code>http://localhost[:port-number]</code> is accepted.
@@ -813,7 +815,8 @@ A browser link is output to the standard output stream.
 <dt>interactive</dt>
 <dd>
 Authenticate interactively by logging in to a cloud account with your
-default web browser. The browser window is opened automatically.
+default web browser. The browser window is opened automatically. The optional
+<code>tenantId</code> parameter may be configured to target a specific tenant.
 </dd>
 <dt>auto-detect</dt>
 <dd>

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/authentication/TokenCredentialFactory.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/authentication/TokenCredentialFactory.java
@@ -202,15 +202,15 @@ public final class TokenCredentialFactory
 
   /**
    * Returns credentials for interactive authentication in a web browser.
-   * @param parameterSet Configures the request with a client ID (optional), and
-   * redirect URL (required).
+   * @param parameterSet Configures the request with optional tenant ID, client ID,
+   * and redirect URL.
    * @return Credentials for interactive authentication
-   * //throws //TODO: What does this throw?
    */
   private static InteractiveBrowserCredential interactiveCredentials(
     ParameterSet parameterSet) {
     return new InteractiveBrowserCredentialBuilder()
       .clientId(parameterSet.getOptional(CLIENT_ID))
+      .tenantId(parameterSet.getOptional(TENANT_ID))
       .redirectUrl(parameterSet.getOptional(REDIRECT_URL))
       .build();
   }


### PR DESCRIPTION
This PR adds support for the optional `AZURE_TENANT_ID` or `tenantId` parameter when using Azure interactive authentication.
When `authenticationMethod=interactive` or `AUTHENTICATION=AZURE_INTERACTIVE` is used, the provider now passes `tenantId` to `InteractiveBrowserCredentialBuilder` if the user configured it, allowing interactive authentication against that tenant. If `tenantId` is not provided, the behavior remains unchanged.
The README was also updated to change `AZURE_CLIENT_ID ` from required to optional for interactive authentication, and to fix the `authenticationMethod=interactive` wording.