### PR TITLE
handle base64 GCP Secret Manager wallets

### DIFF
--- a/ojdbc-provider-gcp/README.md
+++ b/ojdbc-provider-gcp/README.md
@@ -180,7 +180,7 @@ For the JSON type of provider (GCP Object Storage, HTTP/HTTPS, File) the passwor
 
 ### Wallet_location JSON Object
 
-The `oracle.net.wallet_location` connection property is not allowed in the "jdbc" object due to security reasons. Instead, users should use the `wallet_location object to specify the wallet in the configuration.
+The `oracle.net.wallet_location` connection property is not allowed in the "jdbc" object due to security reasons. Instead, users should use the `wallet_location` object to specify the wallet in the configuration.
 
 For the JSON type of provider (GCP Cloud Storage, HTTPS, File) the `wallet_location` is an object itself with the same spec as the [password JSON object](#password-json-object) mentioned above.
 
@@ -189,7 +189,7 @@ The value stored in the secret can be either:
   - The Base64 representation of a supported wallet file.
   - The raw bytes of the wallet file, stored as an imported secret.
 
-In both cases, the provider will automatically handle the content. If the secret contains raw bytes (e.g., an imported `cwallet.sso` or `ewallet.pem` file), the provider will perform Base64 encoding as needed. The resulting format is equivalent to setting the oracle.net.wallet_location` connection property in a regular JDBC application using the following format:
+In both cases, the provider will automatically handle the content. If the secret contains raw bytes (e.g., an imported `cwallet.sso` or `ewallet.pem` file), the provider will perform Base64 encoding as needed. The resulting format is equivalent to setting the `oracle.net.wallet_location` connection property in a regular JDBC application using the following format:
 ```
 data:;base64,<Base64 representation of the wallet file>
 ```

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpJsonSecretManagerProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpJsonSecretManagerProvider.java
@@ -46,12 +46,16 @@ import oracle.jdbc.provider.gcp.secrets.GcpSecretManagerFactory;
 import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.spi.OracleConfigurationSecretProvider;
 
+import static oracle.jdbc.provider.util.FileUtils.isBase64Encoded;
+
 public class GcpJsonSecretManagerProvider implements OracleConfigurationSecretProvider {
 
   /**
    * {@inheritDoc}
    * <p>
-   * Returns the password of the Secret that is retrieved from GCP Secrets.
+   * Returns the content of a Secret that is retrieved from GCP Secret Manager.
+   * This provider can be used for {@code password}, {@code wallet_location},
+   * or both.
    * </p>
    * <p>
    * The JSON object has the following form:
@@ -59,8 +63,12 @@ public class GcpJsonSecretManagerProvider implements OracleConfigurationSecretPr
    * 
    * <pre>{@code
    *   "password": {
-  *       "type": "gcpsecretmanager",
-  *       "value": "projects/<project_name>/secrets/<secret_name>/versions/<version>",
+   *       "type": "gcpsecretmanager",
+   *       "value": "projects/<project_name>/secrets/<secret_name>/versions/<version>",
+   *   },
+   *   "wallet_location": {
+   *       "type": "gcpsecretmanager",
+   *       "value": "projects/<project_name>/secrets/<secret_name>/versions/<version>"
    *   }
    * }</pre>
    *
@@ -74,8 +82,15 @@ public class GcpJsonSecretManagerProvider implements OracleConfigurationSecretPr
     ParameterSet parameterSet = GcpConfigurationParameters.getParser().parseNamedValues(
       secretProperties);
 
-    ByteString stringData = GcpSecretManagerFactory.getInstance().request(parameterSet).getContent().getData();
-    return Base64.getEncoder().encodeToString(stringData.toByteArray()).toCharArray();
+    ByteString stringData = GcpSecretManagerFactory.getInstance()
+      .request(parameterSet)
+      .getContent()
+      .getData();
+
+    byte[] secretBytes = stringData.toByteArray();
+    return isBase64Encoded(secretBytes)
+      ? stringData.toStringUtf8().toCharArray()
+      : Base64.getEncoder().encodeToString(secretBytes).toCharArray();
   }
 
   @Override


### PR DESCRIPTION
This PR fixes an issue where `wallet_location` in a JSON config fails when the wallet is stored in GCP Secret Manager as Base64 text.
The GCP provider was always Base64-encoding the retrieved secret, which double-encoded already-Base64 wallets. It now returns Base64 payloads as-is and only encodes raw wallet bytes.

Fixes: #204 