### PR TITLE
Support configurable parsers for cloud config payloads

### DIFF
--- a/ojdbc-provider-aws/README.md
+++ b/ojdbc-provider-aws/README.md
@@ -16,6 +16,8 @@ Provider</a></dt>
 <dd>Provides connection properties managed by the Systems Manager Parameter Store</dd>
 <dt><a href="#aws-appconfig-freeform-config-provider">AWS AppConfig Freeform Configuration Provider</a></dt>
 <dd>Provides connection properties managed by the AWS AppConfig Freeform Configuration service</dd>
+<dt><a href="#configuration-payload-parsers-json-pkl-and-other-parsers">Configuration Payload Parsers (JSON, Pkl, and Other Parsers)</a></dt>
+<dd>Parser selection for AWS centralized configuration payloads</dd>
 <dt><a href="#common-parameters-for-centralized-config-providers">Common Parameters for Centralized Config Providers</a></dt>
 <dd>Common parameters supported by the config providers</dd>
 <dt><a href="#caching-configuration">Caching configuration</a></dt>
@@ -65,7 +67,7 @@ JDK versions. The coordinates for the latest release are:
 
 ## AWS S3 Configuration Provider
 The Oracle DataSource uses a new prefix `jdbc:oracle:thin:@config-awss3:` to be able to identify that the configuration parameters should be loaded using AWS S3.
-Users only need to indicate the S3 URI of the object that contains the JSON payload.
+Users only need to indicate the S3 URI of the object that contains the configuration payload.
 
 A URL with either of the following formats is valid:
 <pre>
@@ -78,7 +80,7 @@ jdbc:oracle:thin:@config-aws{S3-URI}
 
 The {S3-URI} can be obtained from the Amazon S3 console and follows this naming convention: s3://bucket-name/file-name.
 
-### JSON Payload format
+### Configuration Payload Format
 
 There are 4 fixed values that are looked at the root level.
 
@@ -195,23 +197,23 @@ This property should be included inside the jdbc object of the JSON payload:
 <i>*Note: When storing a wallet in AWS Secrets Manager, store the raw Base64-encoded wallet bytes directly. The provider will automatically detect and handle the encoding correctly.</i>
 
 ## AWS Secrets Manager Config Provider
-Apart from AWS S3, users can also store JSON Payload in the content of AWS Secrets Manager secret. Users need to indicate the secret name:
+Apart from AWS S3, users can also store a configuration payload in the content of AWS Secrets Manager secret. Users need to indicate the secret name:
 
 <pre>
 jdbc:oracle:thin:@config-awssecretsmanager://{secret-name}
 </pre>
 
-The JSON Payload retrieved by AWS Secrets Manager Provider follows the same format in [AWS S3 Configuration Provider](#json-payload-format).
+The payload retrieved by AWS Secrets Manager Provider follows the same format in [AWS S3 Configuration Provider](#configuration-payload-format).
 
 ## AWS Parameter Store Config Provider
-Apart from AWS S3 and Secrets Manager, users can also store JSON payload in AWS Systems Manager Parameter Store. 
+Apart from AWS S3 and Secrets Manager, users can also store a configuration payload in AWS Systems Manager Parameter Store.
 To use it, specify the name of the parameter:
 
 <pre>
 jdbc:oracle:thin:@config-awsparameterstore://{parameter-name}
 </pre>
 
-The JSON payload stored in the parameter should follow the same format as described in [AWS S3 Configuration Provider](#json-payload-format).
+The payload stored in the parameter should follow the same format as described in [AWS S3 Configuration Provider](#configuration-payload-format).
 
 ## AWS AppConfig Freeform Config Provider
 The Oracle DataSource uses the prefix `jdbc:oracle:thin:@config-awsappconfig` to identify that the freeform
@@ -237,14 +239,30 @@ jdbc:oracle:thin:@config-awsappconfig://app-name?appconfig_environment=your-envi
 Alternatively, you can set the environment and profile via system properties (`aws.appconfig.environment, aws.appconfig.profile`) or
 environment variables (`AWS_APP_CONFIG_ENVIRONMENT, AWS_APP_CONFIG_PROFILE`).
 
+## Configuration Payload Parsers (JSON, Pkl, and Other Parsers)
+AWS S3, AWS Secrets Manager, AWS Parameter Store, and AWS AppConfig Freeform
+Config Providers extend `OracleConfigurationParsableProvider`, which parses
+payloads as JSON by default and honors the `parser` option for other parser
+types. To use a Pkl payload, or another parser type, add the `parser` option to
+the JDBC URL and include the corresponding parser provider on the runtime
+classpath. For Pkl, include `ojdbc-provider-pkl`.
+
+<pre>
+jdbc:oracle:thin:@config-awss3://{S3-URI}?parser=pkl
+jdbc:oracle:thin:@config-awssecretsmanager://{secret-name}?parser=pkl
+jdbc:oracle:thin:@config-awsparameterstore://{parameter-name}?parser=pkl
+jdbc:oracle:thin:@config-awsappconfig://{application-identifier}?appconfig_environment={environment-id-or-name}&appconfig_profile={profile-id-or-name}&parser=pkl
+</pre>
+
 ## Common Parameters for Centralized Config Providers
-AWS S3 Configuration Provider and AWS Secrets Manager Configuration Provider
-share the same sets of parameters for authentication configuration.
+AWS S3 Configuration Provider, AWS Secrets Manager Configuration Provider, AWS
+Parameter Store Configuration Provider, and AWS AppConfig Freeform Configuration
+Provider share the same set of parameters for authentication configuration.
 
 ### Configuring Authentication
 
 The Centralized Config Providers in this module use the
-[Default credentials provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html) to provide authorization and authentication to S3 and Secrets Manager services.
+[Default credentials provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html) to provide authorization and authentication to AWS services.
 The user can provide an optional parameter `AUTHENTICATION` (case-ignored) which is mapped with the following Credential Class.
 
 <table>

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/configuration/AwsAppConfigConfigurationProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/configuration/AwsAppConfigConfigurationProvider.java
@@ -53,9 +53,10 @@ import static oracle.jdbc.provider.aws.configuration.AwsConfigurationParameters.
 import static oracle.jdbc.provider.aws.configuration.AwsConfigurationParameters.REGION;
 
 /**
- * A provider for JSON payload which contains configuration data from AWS
- * AppConfig
- * See {@link #getInputStream(String)} for the spec of the JSON payload.
+ * A provider for configuration payloads retrieved from AWS AppConfig. Payloads
+ * are parsed by {@link OracleConfigurationParsableProvider}; JSON is used by
+ * default, and other parser types such as Pkl may be selected with the
+ * {@code parser} option.
  **/
 public class AwsAppConfigConfigurationProvider extends OracleConfigurationParsableProvider {
 
@@ -84,6 +85,8 @@ public class AwsAppConfigConfigurationProvider extends OracleConfigurationParsab
   public InputStream getInputStream(String parameterName) {
     final String VALUE = "value";
     Map<String, String> opts = new HashMap<>(options);
+    // "parser" is consumed by OracleConfigurationParsableProvider, not AWS.
+    opts.remove("parser");
     opts.put(VALUE, parameterName);
 
     ParameterSet parameters = PARAMETER_SET_PARSER.parseNamedValues(opts);
@@ -105,14 +108,5 @@ public class AwsAppConfigConfigurationProvider extends OracleConfigurationParsab
   @Override
   public OracleConfigurationCache getCache() {
     return CACHE;
-  }
-
-  /**
-   * {@inheritDoc}
-   * @return the parser type
-   */
-  @Override
-  public String getParserType(String location) {
-    return "json";
   }
 }

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/configuration/AwsParameterStoreConfigurationProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/configuration/AwsParameterStoreConfigurationProvider.java
@@ -54,9 +54,11 @@ import static oracle.jdbc.provider.aws.configuration.AwsConfigurationParameters.
 import static oracle.jdbc.provider.aws.configuration.AwsConfigurationParameters.REGION;
 
 /**
- * A provider for JSON payload which contains configuration from AWS Systems
- * Manager Parameter Store.
- * See {@link #getInputStream(String)} for the spec of the JSON payload.
+ * A provider for configuration payloads retrieved from AWS Systems Manager
+ * Parameter Store. Payloads are parsed by
+ * {@link OracleConfigurationParsableProvider}; JSON is used by default, and
+ * other parser types such as Pkl may be selected with the {@code parser}
+ * option.
  **/
 public class AwsParameterStoreConfigurationProvider
   extends OracleConfigurationParsableProvider {
@@ -86,6 +88,8 @@ public class AwsParameterStoreConfigurationProvider
     // The JSON “value” field holds the Parameter Store name
     final String VALUE = "value";
     Map<String, String> opts = new HashMap<>(options);
+    // "parser" is consumed by OracleConfigurationParsableProvider, not AWS.
+    opts.remove("parser");
     opts.put(VALUE, parameterName);
 
     ParameterSet params = PARAMETER_SET_PARSER.parseNamedValues(opts);
@@ -108,14 +112,5 @@ public class AwsParameterStoreConfigurationProvider
   @Override
   public OracleConfigurationCache getCache() {
     return CACHE;
-  }
-
-  /**
-   * {@inheritDoc}
-   * @return the parser type
-   */
-  @Override
-  public String getParserType(String location) {
-    return "json";
   }
 }

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/configuration/AwsS3ConfigurationProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/configuration/AwsS3ConfigurationProvider.java
@@ -51,8 +51,10 @@ import static oracle.jdbc.provider.aws.configuration.AwsConfigurationParameters.
 import static oracle.jdbc.provider.aws.s3.S3Factory.S3_URL;
 
 /**
- * A provider for JSON payload which contains configuration from AWS S3.
- * See {@link #getInputStream(String)} for the spec of the JSON payload.
+ * A provider for configuration payloads retrieved from AWS S3. Payloads are
+ * parsed by {@link OracleConfigurationParsableProvider}; JSON is used by
+ * default, and other parser types such as Pkl may be selected with the
+ * {@code parser} option.
  **/
 public class AwsS3ConfigurationProvider extends OracleConfigurationParsableProvider {
 
@@ -84,6 +86,8 @@ public class AwsS3ConfigurationProvider extends OracleConfigurationParsableProvi
 
         // Add objectUrl to the "options" Map, so it can be parsed.
         Map<String, String> optionsWithUrl = new HashMap<>(options);
+        // "parser" is consumed by OracleConfigurationParsableProvider, not AWS.
+        optionsWithUrl.remove("parser");
         optionsWithUrl.put("s3_url", s3Url);
 
         ParameterSet parameters =
@@ -106,14 +110,5 @@ public class AwsS3ConfigurationProvider extends OracleConfigurationParsableProvi
     @Override
     public OracleConfigurationCache getCache() {
         return CACHE;
-    }
-
-    /**
-     * {@inheritDoc}
-     * @return the parser type
-     */
-    @Override
-    public String getParserType(String location) {
-        return "json";
     }
 }

--- a/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/configuration/AwsSecretsManagerConfigurationProvider.java
+++ b/ojdbc-provider-aws/src/main/java/oracle/jdbc/provider/aws/configuration/AwsSecretsManagerConfigurationProvider.java
@@ -50,9 +50,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A provider for JSON payload which contains configuration from AWS Secrets
- * Manager.
- * See {@link #getInputStream(String)} for the spec of the JSON payload.
+ * A provider for configuration payloads retrieved from AWS Secrets Manager.
+ * Payloads are parsed by {@link OracleConfigurationParsableProvider}; JSON is
+ * used by default, and other parser types such as Pkl may be selected with the
+ * {@code parser} option.
  **/
 public class AwsSecretsManagerConfigurationProvider extends OracleConfigurationParsableProvider {
 
@@ -85,6 +86,8 @@ public class AwsSecretsManagerConfigurationProvider extends OracleConfigurationP
   public InputStream getInputStream(String secretName) {
     final String valueFieldName = "value";
     Map<String, String> optionsWithSecret = new HashMap<>(options);
+    // "parser" is consumed by OracleConfigurationParsableProvider, not AWS.
+    optionsWithSecret.remove("parser");
     optionsWithSecret.put(valueFieldName, secretName);
 
     ParameterSet parameters = PARAMETER_SET_PARSER.parseNamedValues(optionsWithSecret);
@@ -108,14 +111,5 @@ public class AwsSecretsManagerConfigurationProvider extends OracleConfigurationP
   @Override
   public OracleConfigurationCache getCache() {
     return CACHE;
-  }
-
-  /**
-   * {@inheritDoc}
-   * @return the parser type
-   */
-  @Override
-  public String getParserType(String location) {
-    return "json";
   }
 }

--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -9,6 +9,8 @@ This module contains providers for integration between Oracle JDBC and Azure.
 <dd>Provides connection properties managed by the App Configuration service</dd>
 <dt><a href="#azure-vault-config-provider">Azure Vault Config Provider</a></dt>
 <dd>Provides connection properties managed by the Key Vault service</dd>
+<dt><a href="#configuration-payload-parsers-json-pkl-and-other-parsers">Configuration Payload Parsers (JSON, Pkl, and Other Parsers)</a></dt>
+<dd>Parser selection for Azure Vault configuration payloads</dd>
 <dt><a href="#common-parameters-for-centralized-config-providers">Common Parameters for Centralized Config Providers</a></dt>
 <dd>Common parameters supported by the config providers</dd>
 <dt><a href="#caching-configuration">Caching configuration</a></dt>
@@ -160,7 +162,7 @@ This property should be included inside the jdbc object of the JSON payload:
 
 
 ## Azure Vault Config Provider
-Similar to [OCI Vault Config Provider](../ojdbc-provider-oci/README.md#oci-vault-config-provider), JSON Payload can also be stored in the content of Azure Key Vault Secret.
+Similar to [OCI Vault Config Provider](../ojdbc-provider-oci/README.md#oci-vault-config-provider), a configuration payload can also be stored in the content of Azure Key Vault Secret.
 The Oracle Data Source uses a new prefix `jdbc:oracle:thin:@config-azurevault://`. Users only need to indicate the Vault Secret’s secret identifier using the following syntax, where option-value pairs separated by `&` are optional authentication parameters that vary by provider:
 
 <pre>
@@ -169,7 +171,18 @@ jdbc:oracle:thin:@config-azurevault://{secret-identifier}[?option1=value1&option
 
 For more details about the option-value pairs, see [Common Parameters for Centralized Config Providers](#common-parameters-for-centralized-config-providers).
 
-To view an example format of JSON Payload, please refer to [JSON Payload format](../ojdbc-provider-oci/README.md#json-payload-format).
+To view an example format of the configuration payload, please refer to [Configuration Payload Format](../ojdbc-provider-oci/README.md#configuration-payload-format).
+
+## Configuration Payload Parsers (JSON, Pkl, and Other Parsers)
+Azure Vault Config Provider extends `OracleConfigurationParsableProvider`, which
+parses payloads as JSON by default and honors the `parser` option for other
+parser types. To use a Pkl payload, or another parser type, add the `parser`
+option to the JDBC URL and include the corresponding parser provider on the
+runtime classpath. For Pkl, include `ojdbc-provider-pkl`.
+
+<pre>
+jdbc:oracle:thin:@config-azurevault://{secret-identifier}?parser=pkl
+</pre>
 
 ## Common Parameters for Centralized Config Providers
 Provider that are classified as Centralized Config Providers in this module share the same sets of parameters for authentication configuration.

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureVaultJsonProvider.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureVaultJsonProvider.java
@@ -51,8 +51,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A provider for JSON payload which contains configuration from Azure Vault.
- * See {@link #getInputStream(String)} for the spec of the JSON payload.
+ * A provider for configuration payloads retrieved from Azure Vault. Payloads
+ * are parsed by {@link OracleConfigurationParsableProvider}; JSON is used by
+ * default, and other parser types such as Pkl may be selected with the
+ * {@code parser} option.
  */
 public class AzureVaultJsonProvider extends OracleConfigurationParsableProvider {
 
@@ -77,19 +79,22 @@ public class AzureVaultJsonProvider extends OracleConfigurationParsableProvider 
   /**
    * {@inheritDoc}
    * <p>
-   * Returns the JSON payload stored in Azure Vault Secret.
+   * Returns the configuration payload stored in Azure Vault Secret.
    * </p><p>The {@code secretIdentifier} is an identifier of Vault Secret which
-   * can be acquired on the Azure Web Console. The Json payload is stored in
-   * the Secret Value of Vault Secret.
+   * can be acquired on the Azure Web Console. The configuration payload is
+   * stored in the Secret Value of Vault Secret.
    * </p>
    * @param secretIdentifier the identifier of secret used by this
-   *                         provider to retrieve JSON payload from Azure
-   * @return JSON payload
+   *                         provider to retrieve a configuration payload from
+   *                         Azure
+   * @return configuration payload
    **/
   @Override
   public InputStream getInputStream(String secretIdentifier) {
     final String valueFieldName = "value";
     Map<String, String> optionsWithSecret = new HashMap<>(options);
+    // "parser" is consumed by OracleConfigurationParsableProvider, not Azure.
+    optionsWithSecret.remove("parser");
     optionsWithSecret.put(valueFieldName, secretIdentifier);
 
     ParameterSet parameters = PARAMETER_SET_PARSER
@@ -116,11 +121,6 @@ public class AzureVaultJsonProvider extends OracleConfigurationParsableProvider 
   @Override
   public String getType() {
     return "azurevault";
-  }
-
-  @Override
-  public String getParserType(String arg0) {
-    return "json";
   }
 
   /**

--- a/ojdbc-provider-gcp/README.md
+++ b/ojdbc-provider-gcp/README.md
@@ -9,9 +9,11 @@ Google Cloud Platform (GCP).
 <dt><a href="#gcp-cloud-storage-config-provider">GCP Cloud Storage Config 
 Provider</a></dt>
 <dd>Provides connection properties managed by the Cloud Storage service</dd>
-<dt><a href="#gcp-secret_manager-config-provider">GCP Secret Manager Config 
+<dt><a href="#gcp-secret-manager-config-provider">GCP Secret Manager Config 
 Provider</a></dt>
 <dd>Provides connection properties managed by the Secret Manager service</dd>
+<dt><a href="#configuration-payload-parsers-json-pkl-and-other-parsers">Configuration Payload Parsers (JSON, Pkl, and Other Parsers)</a></dt>
+<dd>Parser selection for GCP configuration payloads</dd>
 <dt><a href="#caching-configuration">Caching configuration</a></dt>
 <dd>Caching mechanism adopted by Centralized Config Providers</dd>
 </dl>
@@ -77,7 +79,7 @@ gcloud auth application-default login
 A sign-in screen appears. After you sign in, your credentials are stored in the local credential file used by ADC.
 
 ## GCP Cloud Storage Config Provider
-The Oracle DataSource uses a new prefix `jdbc:oracle:thin:@config-gcpstorage:` to be able to identify that the configuration parameters should be loaded using GCP Object Storage. Users only need to indicate the project, bucket and object containing the JSON payload, with the following syntax:
+The Oracle DataSource uses a new prefix `jdbc:oracle:thin:@config-gcpstorage:` to be able to identify that the configuration parameters should be loaded using GCP Object Storage. Users only need to indicate the project, bucket and object containing the configuration payload, with the following syntax:
 
 <pre>
 jdbc:oracle:thin:@config-gcpstorage://project={project};bucket={bucket};object={object}
@@ -100,7 +102,7 @@ Google Cloud Java SDK. See the Google Cloud Storage documentation for
 [gs:// URIs](https://docs.cloud.google.com/storage/docs/downloading-objects)
 and [storage.googleapis.com object URLs](https://docs.cloud.google.com/storage/docs/access-public-data).
 
-### JSON Payload format
+### Configuration Payload Format
 
 There are 3 fixed values that are looked at the root level.
 
@@ -210,13 +212,27 @@ This property should be included inside the jdbc object of the JSON payload:
 <i>*Note: When storing a wallet in GCP Secret Manager, you can either store the raw bytes of the cwallet.sso file directly or provide the Base64-encoded string. The provider will detect the format and handle the encoding appropriately.</i>
 
 ## GCP Secret Manager Config Provider
-Apart from GCP Cloud Storage, users can also store JSON Payload in the content of GCP Secret Manager secret. Users need to indicate the resource name:
+Apart from GCP Cloud Storage, users can also store a configuration payload in the content of GCP Secret Manager secret. Users need to indicate the resource name:
 
 <pre>
 jdbc:oracle:thin:@config-gcpsecretmanager:{resource-name}
 </pre>
 
-The JSON Payload retrieved by GCP Vault Config Provider follows the same format in [GCP Object Storage Config Provider](#json-payload-format).
+The payload retrieved by GCP Secret Manager Config Provider follows the same format in [GCP Object Storage Config Provider](#configuration-payload-format).
+
+## Configuration Payload Parsers (JSON, Pkl, and Other Parsers)
+GCP Cloud Storage and GCP Secret Manager Config Providers extend
+`OracleConfigurationParsableProvider`, which parses payloads as JSON by default
+and honors the `parser` option for other parser types. To use a Pkl payload, or
+another parser type, add the `parser` option to the JDBC URL and include the
+corresponding parser provider on the runtime classpath. For Pkl, include
+`ojdbc-provider-pkl`.
+
+<pre>
+jdbc:oracle:thin:@config-gcpstorage://project={project};bucket={bucket};object={object}?parser=pkl
+jdbc:oracle:thin:@config-gcpstorage://gs://{bucket}/{object}?parser=pkl
+jdbc:oracle:thin:@config-gcpsecretmanager:{resource-name}?parser=pkl
+</pre>
 
 ## Caching configuration
 

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpCloudStorageConfigurationProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpCloudStorageConfigurationProvider.java
@@ -50,8 +50,10 @@ import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.util.OracleConfigurationCache;
 
 /**
- * A provider for JSON payload which contains configuration from GCP Cloud
- * Storage. See {@link #getInputStream(String)} for the spec of the JSON payload.
+ * A provider for configuration payloads retrieved from GCP Cloud Storage.
+ * Payloads are parsed by {@link OracleConfigurationParsableProvider}; JSON is
+ * used by default, and other parser types such as Pkl may be selected with the
+ * {@code parser} option.
  */
 public class GcpCloudStorageConfigurationProvider
     extends OracleConfigurationParsableProvider {
@@ -72,16 +74,16 @@ public class GcpCloudStorageConfigurationProvider
   /**
    * {@inheritDoc}
    * <p>
-   * Returns the JSON payload stored in GCP Cloud Storage.
+   * Returns the configuration payload stored in GCP Cloud Storage.
    * </p>
    * 
    * @param location semi-colon separated list of key value pairs
    *                 containing the following keys:
    *                 <ul>
    *                 <li>project: the project id (optional)</li>
-   *                 <li>bucket: the bucket containing the json configuration
+   *                 <li>bucket: the bucket containing the configuration
    *                 file</li>
-   *                 <li>object: the name of the json configuration file</li>
+   *                 <li>object: the name of the configuration file</li>
    *                 </ul>
    *                 Unknown keys will be ignored.
    *                 Ex: project=myProject;bucket=myBucket;object=myfile.json
@@ -97,7 +99,7 @@ public class GcpCloudStorageConfigurationProvider
    *                 When using URI-based formats, the provider uses the
    *                 default Google Cloud Storage client configuration resolved
    *                 by the Google Cloud Java SDK.
-   * @return JSON payload
+   * @return configuration payload
    */
   @Override
   public InputStream getInputStream(String location) throws SQLException {

--- a/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpSecretManagerConfigurationProvider.java
+++ b/ojdbc-provider-gcp/src/main/java/oracle/jdbc/provider/gcp/configuration/GcpSecretManagerConfigurationProvider.java
@@ -49,9 +49,10 @@ import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.util.OracleConfigurationCache;
 
 /**
- * A provider for JSON payload which contains configuration from GCP Secret
- * Manager.
- * See {@link #getInputStream(String)} for the spec of the JSON payload.
+ * A provider for configuration payloads retrieved from GCP Secret Manager.
+ * Payloads are parsed by {@link OracleConfigurationParsableProvider}; JSON is
+ * used by default, and other parser types such as Pkl may be selected with the
+ * {@code parser} option.
  **/
 public class GcpSecretManagerConfigurationProvider
     extends OracleConfigurationParsableProvider {
@@ -66,12 +67,12 @@ public class GcpSecretManagerConfigurationProvider
   /**
    * {@inheritDoc}
    * <p>
-   * Returns the JSON payload stored in GCP Secret Manager secret.
+   * Returns the configuration payload stored in GCP Secret Manager secret.
    * </p>
    * 
    * @param location resource name of the secret version (to obtain the resource
    *                 name, click on "Actions" and "Copy resource name")
-   * @return JSON payload
+   * @return configuration payload
    */
   @Override
   public InputStream getInputStream(String location) throws SQLException {
@@ -89,10 +90,5 @@ public class GcpSecretManagerConfigurationProvider
   @Override
   public OracleConfigurationCache getCache() {
     return CACHE;
-  }
-
-  @Override
-  public String getParserType(String arg0) {
-    return "json";
   }
 }

--- a/ojdbc-provider-hashicorp/README.md
+++ b/ojdbc-provider-hashicorp/README.md
@@ -7,6 +7,8 @@ and HashiCorp Vault (HCP).
 <dl>
 <dt><a href="#hcp-vault-dedicated-config-provider">HashiCorp Vault Dedicated Config Provider</a></dt>
 <dd>Provides connection properties managed by the Dedicated Vault service</dd>
+<dt><a href="#configuration-payload-parsers-json-pkl-and-other-parsers">Configuration Payload Parsers (JSON, Pkl, and Other Parsers)</a></dt>
+<dd>Parser selection for HCP Vault Dedicated configuration payloads</dd>
 <dt><a href="#caching-configuration">Caching configuration</a></dt>
 <dd>Caching mechanism adopted by Centralized Config Providers</dd>
 </dl>
@@ -312,7 +314,7 @@ The query parameters (`option1=value1`, `option2=value2`, etc.) are optional key
 jdbc:oracle:thin:@config-hcpvaultdedicated:///v1/namespace/secret/data/secret_name?KEY=sales_app1&authentication=approle
 ```
 
-### JSON Payload format
+### Configuration Payload Format
 
 There are 4 fixed values that are looked at the root level:
 
@@ -364,6 +366,19 @@ The sample code below executes as expected with the previous configuration.
     if (rs.next())
       System.out.println("select sysdate from dual: " + rs.getString(1));
 ```
+
+### Configuration Payload Parsers (JSON, Pkl, and Other Parsers)
+
+HCP Vault Dedicated Config Provider extends
+`OracleConfigurationParsableProvider`, which parses payloads as JSON by default
+and honors the `parser` option for other parser types. To use a Pkl payload, or
+another parser type, add the `parser` option to the JDBC URL and include the
+corresponding parser provider on the runtime classpath. For Pkl, include
+`ojdbc-provider-pkl`.
+
+<pre>
+jdbc:oracle:thin:@config-hcpvaultdedicated://{secret-path}?parser=pkl
+</pre>
 
 ### Password JSON Object
 

--- a/ojdbc-provider-hashicorp/src/main/java/oracle/jdbc/provider/hashicorp/hcpvaultdedicated/configuration/DedicatedVaultSecretsManagerConfigurationProvider.java
+++ b/ojdbc-provider-hashicorp/src/main/java/oracle/jdbc/provider/hashicorp/hcpvaultdedicated/configuration/DedicatedVaultSecretsManagerConfigurationProvider.java
@@ -51,6 +51,12 @@ import java.util.Map;
 
 import static oracle.jdbc.provider.hashicorp.hcpvaultdedicated.authentication.DedicatedVaultParameters.*;
 
+/**
+ * A provider for configuration payloads retrieved from HCP Vault Dedicated.
+ * Payloads are parsed by {@link OracleConfigurationParsableProvider}; JSON is
+ * used by default, and other parser types such as Pkl may be selected with the
+ * {@code parser} option.
+ */
 public class DedicatedVaultSecretsManagerConfigurationProvider extends OracleConfigurationParsableProvider {
 
   private static final OracleConfigurationCache CACHE = OracleConfigurationCache.create(100);
@@ -60,6 +66,8 @@ public class DedicatedVaultSecretsManagerConfigurationProvider extends OracleCon
     final String valueFieldName = "value";
 
     Map<String, String> optionsWithSecret = new HashMap<>(options);
+    // "parser" is consumed by OracleConfigurationParsableProvider, not HCP Vault.
+    optionsWithSecret.remove("parser");
     optionsWithSecret.put(valueFieldName, secretPath);
 
     ParameterSet finalParameters = buildResolvedParameterSet(optionsWithSecret);
@@ -75,11 +83,6 @@ public class DedicatedVaultSecretsManagerConfigurationProvider extends OracleCon
   @Override
   public String getType() {
     return "hcpvaultdedicated";
-  }
-
-  @Override
-  public String getParserType(String location) {
-    return "json";
   }
 
   @Override

--- a/ojdbc-provider-oci/README.md
+++ b/ojdbc-provider-oci/README.md
@@ -15,6 +15,8 @@ Provider</a></dt>
 <dd>Provides connection properties managed by the Object Storage service</dd>
 <dt><a href="#oci-vault-config-provider">OCI Vault Config Provider</a></dt>
 <dd>Provides connection properties managed by the Vault service</dd>
+<dt><a href="#configuration-payload-parsers-json-pkl-and-other-parsers">Configuration Payload Parsers (JSON, Pkl, and Other Parsers)</a></dt>
+<dd>Parser selection for Object Storage and Vault configuration payloads</dd>
 <dt><a href="#common-parameters-for-centralized-config-providers">Common Parameters for Centralized Config Providers</a></dt>
 <dd>Common parameters supported by the config providers</dd>
 <dt><a href="#caching-configuration">Caching configuration</a></dt>
@@ -83,7 +85,7 @@ Provider can now support Database Tools Connections with Proxy Authentication,
 only if username is provided in Proxy Authentication Info, without the password and roles.
 
 ## OCI Object Storage Config Provider
-The Oracle Data Source uses a new prefix `jdbc:oracle:thin:@config-ociobject://` to be able to identify that the configuration parameters should be loaded using OCI Object Storage. Users only need to indicate the URL Path of the Object containing the JSON payload using the following syntax, where option-value pairs separated by `&` are optional authentication parameters that vary by provider:
+The Oracle Data Source uses a new prefix `jdbc:oracle:thin:@config-ociobject://` to be able to identify that the configuration parameters should be loaded using OCI Object Storage. Users only need to indicate the URL Path of the Object containing the configuration payload using the following syntax, where option-value pairs separated by `&` are optional authentication parameters that vary by provider:
 
 <pre>
 jdbc:oracle:thin:@config-ociobject://{url_path}[?option1=value1&option2=value2...]
@@ -101,7 +103,7 @@ The instructions of obtaining a URL Path can be found in [Get the URI or Pre-Aut
 
 For more details about the option-value pairs, see [Common Parameters for Centralized Config Providers](#common-parameters-for-centralized-config-providers).
 
-### JSON Payload format
+### Configuration Payload Format
 
 There are 4 fixed values that are looked at the root level.
 
@@ -214,18 +216,32 @@ This property should be included inside the "jdbc" object of the JSON payload.
 <i>*Note: When storing a wallet as a secret in OCI Vault, choose the Plain-Text secret type template instead of Base64 to prevent double decoding when the provider retrieves the value.</i> 
 
 ## OCI Vault Config Provider
-Apart from OCI Object Storage, users can also store JSON Payload in the content of OCI Vault Secret. Users need to indicate the OCID of the Secret with the following syntax:
+Apart from OCI Object Storage, users can also store a configuration payload in the content of OCI Vault Secret. Users need to indicate the OCID of the Secret with the following syntax:
 
 <pre>
 jdbc:oracle:thin:@config-ocivault://{secret-ocid}
 </pre>
 
-The JSON Payload retrieved by OCI Vault Config Provider follows the same format in [OCI Object Storage Config Provider](#json-payload-format).
+The payload retrieved by OCI Vault Config Provider follows the same format in [OCI Object Storage Config Provider](#configuration-payload-format).
+
+## Configuration Payload Parsers (JSON, Pkl, and Other Parsers)
+OCI Object Storage and OCI Vault Config Providers extend
+`OracleConfigurationParsableProvider`, which parses payloads as JSON by default
+and honors the `parser` option for other parser types. To use a Pkl payload, or
+another parser type, add the `parser` option to the JDBC URL and include the
+corresponding parser provider on the runtime classpath. For Pkl, include
+`ojdbc-provider-pkl`.
+
+<pre>
+jdbc:oracle:thin:@config-ociobject://{url_path}?parser=pkl
+jdbc:oracle:thin:@config-ocivault://{secret-ocid}?parser=pkl
+</pre>
 
 
 ## Common Parameters for Centralized Config Providers
-OCI Database Tools Connections Config Provider and OCI Object Storage Config Provider
-share the same sets of parameters for authentication configuration.
+OCI Database Tools Connections Config Provider, OCI Object Storage Config Provider,
+and OCI Vault Config Provider share the same set of parameters for
+authentication configuration.
 
 ### Configuring Authentication
 

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciObjectStorageProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciObjectStorageProvider.java
@@ -48,8 +48,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A provider for JSON payload which contains configuration from OCI Object
- * Storage. See {@link #getInputStream(String)} for the spec of the JSON payload.
+ * A provider for configuration payloads stored in OCI Object Storage. Payloads
+ * are parsed by {@link OracleConfigurationParsableProvider}; JSON is used by
+ * default, and other parser types such as Pkl may be selected with the
+ * {@code parser} option.
  */
 public class OciObjectStorageProvider
   extends OracleConfigurationParsableProvider {
@@ -59,7 +61,7 @@ public class OciObjectStorageProvider
   /**
    * {@inheritDoc}
    * <p>
-   * Returns the JSON payload stored in OCI Object Storage.
+   * Returns the configuration payload stored in OCI Object Storage.
    * </p><p>
    * The {@code objectUrl} is a URL which can be acquired on the OCI Web Console,
    * as describe in <a href="https://docs.oracle.com/en/cloud/paas/autonomous-database/dedicated/adbdj/#articletitle">
@@ -68,9 +70,9 @@ public class OciObjectStorageProvider
    *   https://objectstorage.region.oraclecloud.com/n/object-storage-namespace/b/bucket/o/filename
    * }</pre>
    * <p>The https:// prefix is optional.</p>
-   * @param objectUrl the URL used by this provider to retrieve JSON payload
+   * @param objectUrl the URL used by this provider to retrieve the payload
    *                 from OCI
-   * @return JSON payload
+   * @return configuration payload
    */
   @Override
   public InputStream getInputStream(String objectUrl) {
@@ -80,6 +82,8 @@ public class OciObjectStorageProvider
     }
     // Add objectUrl to the "options" Map, so it can be parsed.
     Map<String, String> optionsWithUrl = new HashMap<>(options);
+    // "parser" is consumed by OracleConfigurationParsableProvider, not OCI.
+    optionsWithUrl.remove("parser");
     optionsWithUrl.put("object_url", objectUrl);
 
     ParameterSet parameters =
@@ -101,11 +105,6 @@ public class OciObjectStorageProvider
   @Override
   public String getType() {
     return "ociobject";
-  }
-
-  @Override
-  public String getParserType(String arg0) {
-    return "json";
   }
 
   /**

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciVaultJsonProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciVaultJsonProvider.java
@@ -12,8 +12,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A provider for JSON payload which contains configuration from OCI Vault.
- * See {@link #getInputStream(String)} for the spec of the JSON payload.
+ * A provider for configuration payloads stored in OCI Vault. Payloads are parsed
+ * by {@link OracleConfigurationParsableProvider}; JSON is used by default, and
+ * other parser types such as Pkl may be selected with the {@code parser} option.
  **/
 public class OciVaultJsonProvider extends OracleConfigurationParsableProvider {
 
@@ -22,19 +23,21 @@ public class OciVaultJsonProvider extends OracleConfigurationParsableProvider {
   /**
    * {@inheritDoc}
    * <p>
-   * Returns the JSON payload stored in OCI Vault Secret.
+   * Returns the configuration payload stored in OCI Vault Secret.
    * </p><p>The {@code secretOcid} is an OCID of Vault Secret which can be
-   * acquired on the OCI Web Console. The Json payload is stored in the Secret
+   * acquired on the OCI Web Console. The payload is stored in the Secret
    * Contents of Vault Secret.
    * </p>
    * @param secretOcid the OCID of secret used by this provider to retrieve
-   *                   JSON payload from OCI
-   * @return JSON payload
+   *                   the payload from OCI
+   * @return configuration payload
    **/
   @Override
   public InputStream getInputStream(String secretOcid) {
     final String valueFieldName = "value";
     Map<String, String> optionsWithOcid = new HashMap<>(options);
+    // "parser" is consumed by OracleConfigurationParsableProvider, not OCI.
+    optionsWithOcid.remove("parser");
     optionsWithOcid.put(valueFieldName, secretOcid);
 
     ParameterSet parameters =
@@ -61,11 +64,6 @@ public class OciVaultJsonProvider extends OracleConfigurationParsableProvider {
   @Override
   public String getType() {
     return "ocivault";
-  }
-
-  @Override
-  public String getParserType(String arg0) {
-    return "json";
   }
 
   /**


### PR DESCRIPTION
This PR is for adding support for configurable payload parsers in centralized cloud config providers.

It keeps JSON as the default parser, while allowing users to select `Pkl` or another registered parser with the parser JDBC URL option. The change covers OCI, AWS, Azure Vault, GCP, and HashiCorp config providers, and updates the related README/Javadocs.