### PR TITLE
Cache interactive OCI logins to avoid repeated browser prompts

### DIFF
--- a/ojdbc-provider-oci/README.md
+++ b/ojdbc-provider-oci/README.md
@@ -287,6 +287,10 @@ in Optional Parameters</td>
     so a subsequent authentication attempt will not fail with a <code>BindException</code>.<br>
     The value must be a positive integer. Decimal values are not allowed.<br>
     <b>Default:</b> <code>5</code> minutes
+    <br><br>
+    <code>OCI_USERNAME</code> <br>
+    <i>(Optional)</i> See <a href="#additional-optional-parameters">Additional Optional Parameters</a>.
+    Only affects <code>OCI_INTERACTIVE</code>; it has no effect for other authentication methods.
   </td>
 </tr>
 </tbody>
@@ -331,6 +335,29 @@ The following parameters can be used alongside any supported authentication meth
   <td>
     <i>If not provided, the login URL will default to <code>https://login.oci.oraclecloud.com</code>,
     which may not work for your target region.</i>
+  </td>
+</tr>
+<tr>
+  <td><code>OCI_USERNAME</code></td>
+  <td>
+    Distinguishes otherwise-identical <code>OCI_INTERACTIVE</code> login requests so that
+    one is not reused in place of another. This is <b>not a credential</b> and is never sent
+    to OCI &mdash; it is a caller-chosen label used only to determine whether two requests may
+    share a cached interactive login.<br>
+    <i>For example, if a main configuration and an embedded
+    <a href="#password-json-object">password</a> or
+    <a href="#wallet_location-json-object">wallet_location</a> object are each configured
+    with <code>OCI_INTERACTIVE</code> but are intended to authenticate as different accounts,
+    set a different <code>OCI_USERNAME</code> on each to force separate logins. If omitted on
+    both, they are treated as the same login and may share one browser-based sign-in.</i><br>
+    Has no effect for any authentication method other than <code>OCI_INTERACTIVE</code>.
+  </td>
+  <td>
+    Any string.
+  </td>
+  <td>
+    <i>If not provided, requests that otherwise match on authentication method and region
+    may share a single cached interactive login.</i>
   </td>
 </tr>
 </tbody>
@@ -834,6 +861,20 @@ common set of parameters.
       <td>A region identifier, such as "ap-sydney-1" or "us-langley-1"</td>
       <td><i>No default value. If not configured, then a region from a config file will be used when requesting resources,
         and interactive authentication will connect to <code>https://login.oci.oraclecloud.com</code></i></td>
+    </tr>
+    <tr>
+      <td>username</td>
+      <td>
+        Distinguishes otherwise-identical requests so that a cached resource or interactive
+        login is not reused across them. This is <b>not a credential</b> and is never sent to
+        OCI &mdash; it is a caller-chosen label.<br>
+        <i>For example, a multi-tenant application fetching the same secret OCID on behalf of
+        different end users can set a different <code>username</code> per request, so that one
+        user's cached secret or interactive login is never served in place of another's.</i>
+      </td>
+      <td>Any string.</td>
+      <td><i>No default value. If not configured, requests that otherwise match on every other
+        parameter may share a cached resource or interactive login.</i></td>
     </tr>
     <tr>
       <td>instancePrincipalTimeout</td>

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/authentication/AuthenticationDetailsFactory.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/authentication/AuthenticationDetailsFactory.java
@@ -53,9 +53,13 @@ import oracle.jdbc.provider.factory.Resource;
 import oracle.jdbc.provider.factory.ResourceFactory;
 import oracle.jdbc.provider.parameter.Parameter;
 import oracle.jdbc.provider.parameter.ParameterSet;
+import oracle.jdbc.provider.parameter.ParameterSetBuilder;
 import oracle.jdbc.provider.oci.objectstorage.ObjectFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -169,6 +173,36 @@ public final class AuthenticationDetailsFactory
    */
   public static final Parameter<Region> REGION = Parameter.create();
 
+  /**
+   * <p>
+   * The parameters that identify a previously resolved
+   * {@link AuthenticationMethod#INTERACTIVE} authentication eligible for
+   * reuse, listed in the order that {@link #interactiveIdentity(ParameterSet)}
+   * documents them. Two {@code ParameterSet} instances that agree on the
+   * values of every parameter in this list are considered to represent the
+   * same interactive login, regardless of any other, resource-specific
+   * parameters (a secret's OCID, a Database Tools Connection's OCID, etc)
+   * that either {@code ParameterSet} might also carry.
+   * </p><p>
+   * This list includes {@link #REGION}, which
+   * {@link InteractiveAuthentication#getSessionToken(ParameterSet)} reads to
+   * decide where to send the browser for login, plus {@link #USERNAME},
+   * which exists specifically to let a caller distinguish two interactive
+   * logins that would otherwise look identical. Every other parameter
+   * declared by this class is excluded, so that it cannot affect whether a
+   * cached login is reused. Notably, this excludes
+   * {@link #INTERACTIVE_TIMEOUT}: although
+   * {@code getSessionToken(ParameterSet)} also reads that parameter, it only
+   * configures how long a <em>fresh</em> login waits for the browser, and has
+   * no bearing on the identity of a login that has already completed and
+   * been cached. Including it here would only fragment the cache, splitting
+   * two requests for the same identity into separate logins whenever they
+   * happened to configure a different timeout.
+   * </p>
+   */
+   static final List<Parameter<?>> INTERACTIVE_IDENTITY_PARAMETERS =
+          List.of(AUTHENTICATION_METHOD, REGION, USERNAME);
+
   private static final AuthenticationDetailsFactory INSTANCE =
       new AuthenticationDetailsFactory();
 
@@ -189,26 +223,87 @@ public final class AuthenticationDetailsFactory
    * defined in this class. The {@code parameterSet} is required to contain
    * an {@link #AUTHENTICATION_METHOD}. Additional parameters may be required
    * depending on which authentication method is configured.
+   * </p><p>
+   * When {@link #AUTHENTICATION_METHOD} is
+   * {@link AuthenticationMethod#INTERACTIVE}, the returned resource may wrap
+   * a previously cached login, reused from another request that presented
+   * the same {@link #INTERACTIVE_IDENTITY_PARAMETERS}. See
+   * {@link InteractiveAuthenticationCache}.
    * </p>
    */
   @Override
   public Resource<AbstractAuthenticationDetailsProvider> request(
       ParameterSet parameterSet) {
 
-    AbstractAuthenticationDetailsProvider authenticationDetails =
-        getAuthenticationDetails(parameterSet);
+    AuthenticationMethod authenticationMethod =
+      parameterSet.getRequired(AUTHENTICATION_METHOD);
+
+    if (authenticationMethod == AuthenticationMethod.INTERACTIVE) {
+      ParameterSet identity = interactiveIdentity(parameterSet);
+
+      AbstractAuthenticationDetailsProvider authenticationDetails =
+        InteractiveAuthenticationCache.get(
+          identity,
+          () -> (InteractiveAuthenticationDetails)
+            getAuthenticationDetails(authenticationMethod, parameterSet));
+
+      return Resource.createPermanentResource(authenticationDetails, true);
+    }
 
     // TODO: Check for authentication details that expire, perhaps because a
-    //  config file is updated, or because an interactive session token has
-    //  expired. Return an expiring resource when appropriate.
-    return Resource.createPermanentResource(authenticationDetails, true);
+    //  config file is updated. Return an expiring resource when appropriate.
+    return Resource.createPermanentResource(
+      getAuthenticationDetails(authenticationMethod, parameterSet), true);
+  }
+
+  /**
+   * <p>
+   * Returns a {@code ParameterSet} containing only the values of
+   * {@link #INTERACTIVE_IDENTITY_PARAMETERS} from the given
+   * {@code parameterSet}. This projection is used only as the cache key
+   * passed to {@link InteractiveAuthenticationCache#get(ParameterSet, java.util.function.Supplier)}:
+   * two requests are considered the same login if and only if they agree on
+   * this projection. Resource-specific parameters (a secret's OCID, a
+   * Database Tools Connection's OCID, etc) play no role in authentication,
+   * and would otherwise cause every distinct resource request to miss the
+   * cache, even when made with the same identity.
+   * </p><p>
+   * This projection is not used as the input to a fresh login on a cache
+   * miss: {@code request(ParameterSet)} passes the original, unprojected
+   * {@code parameterSet} for that purpose instead, since
+   * {@link InteractiveAuthentication#getSessionToken(ParameterSet)} may read
+   * parameters that this projection excludes.
+   * </p>
+   *
+   * @param parameterSet Parameters of a resource request. Not null.
+   * @return The {@link #INTERACTIVE_IDENTITY_PARAMETERS} projection of
+   * {@code parameterSet}. Not null.
+   */
+  private static ParameterSet interactiveIdentity(ParameterSet parameterSet) {
+    ParameterSetBuilder builder = ParameterSet.builder();
+
+    for (Parameter<?> parameter : INTERACTIVE_IDENTITY_PARAMETERS)
+      copyValue(builder, parameterSet, parameter);
+
+    return builder.build();
+  }
+
+  /**
+   * Copies the value of a single {@code parameter} from {@code source} into
+   * {@code builder}, if {@code source} contains a value for it. This helper
+   * exists to capture the {@code <T>} type of a {@code Parameter<T>} taken
+   * from a {@code Parameter<?>} list, which
+   * {@link ParameterSetBuilder#add(String, Parameter, Object)} requires.
+   */
+  private static <T> void copyValue(
+    ParameterSetBuilder builder, ParameterSet source, Parameter<T> parameter) {
+
+    if (source.contains(parameter))
+      builder.add(source.getName(parameter), parameter, source.getOptional(parameter));
   }
 
   private static AbstractAuthenticationDetailsProvider getAuthenticationDetails(
-    ParameterSet parameterSet) {
-
-    AuthenticationMethod authenticationMethod =
-      parameterSet.getRequired(AUTHENTICATION_METHOD);
+    AuthenticationMethod authenticationMethod, ParameterSet parameterSet) {
 
     switch (authenticationMethod) {
       case CONFIG_FILE:

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/authentication/InteractiveAuthenticationCache.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/authentication/InteractiveAuthenticationCache.java
@@ -1,0 +1,203 @@
+/*
+ ** Copyright (c) 2026 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.jdbc.provider.oci.authentication;
+
+import oracle.jdbc.provider.parameter.ParameterSet;
+
+import java.time.OffsetDateTime;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.function.Supplier;
+
+/**
+ * <p>
+ * A cache of {@link InteractiveAuthenticationDetails}, keyed on the identity
+ * of an {@link AuthenticationMethod#INTERACTIVE} login (see
+ * {@link AuthenticationDetailsFactory#INTERACTIVE_IDENTITY_PARAMETERS}).
+ * </p><p>
+ * Interactive authentication requires a human to complete a login with a web
+ * browser, which may take anywhere from a few seconds to several minutes.
+ * Requesting a fresh login every time a resource needs to authenticate would
+ * mean prompting that human to log in again and again for what is, from
+ * their perspective, a single sign-in. This class exists so that multiple
+ * requests which share the same identity can reuse one login, for as long as
+ * the session token it produced remains valid.
+ * </p><p>
+ * Two properties of this cache follow from what it stores:
+ * </p><ul>
+ *   <li>
+ *     A failed login is not cached: a login failure (such as a browser
+ *     prompt that timed out) is expected to be retried with a fresh prompt,
+ *     not replayed indefinitely.
+ *   </li>
+ *   <li>
+ *     A session token has a well defined expiration (its "exp" claim), so
+ *     entries are actively removed once they stop being useful.
+ *   </li>
+ * </ul>
+ */
+final class InteractiveAuthenticationCache {
+
+  /**
+   * <p>
+   * Cached logins, keyed on identity. A value may represent a login that is
+   * still in progress ({@link FutureTask#isDone()} is {@code false}), or one
+   * that has completed, either successfully or with a failure.
+   * </p><p>
+   * Entries are never replaced in place: a stale or failed entry is instead
+   * removed (see {@link #removeStaleEntries()}), or superseded by a new
+   * {@code FutureTask} installed by {@link #get(ParameterSet, Supplier)}.
+   * </p>
+   */
+  private static final ConcurrentMap<ParameterSet, FutureTask<InteractiveAuthenticationDetails>>
+    ENTRIES = new ConcurrentHashMap<>();
+
+  private InteractiveAuthenticationCache() {}
+
+  /**
+   * <p>
+   * Returns cached authentication details for the given {@code identity}, or
+   * invokes {@code login} to perform a new login if none is cached.
+   * </p><p>
+   * This is a thread safe method. If multiple threads call this method
+   * concurrently with an equal {@code identity}, and no login is yet cached
+   * for it, only one thread will invoke {@code login}. The other threads
+   * block until that single login completes, and then share its result, or
+   * its failure.
+   * </p>
+   *
+   * @param identity Identifies the login to return. Not null.
+   * @param login Performs a fresh interactive login. Only invoked when no
+   * valid login is already cached for {@code identity}. Not null.
+   * @return Authentication details for {@code identity}, either cached or
+   * freshly obtained from {@code login}. Not null.
+   * @throws IllegalStateException If a fresh login is required, and
+   * {@code login} fails with a checked exception.
+   */
+  static InteractiveAuthenticationDetails get(
+      ParameterSet identity, Supplier<InteractiveAuthenticationDetails> login) {
+
+    removeStaleEntries();
+
+    // removeStaleEntries() guarantees that any entry still present, and
+    // already done, is valid: use it as-is, without touching the map again.
+    // An entry that is present but not yet done belongs to a login already
+    // in progress on another thread; it is also used as-is, so that this
+    // thread waits for that single login rather than starting its own.
+    FutureTask<InteractiveAuthenticationDetails> existingTask = ENTRIES.get(identity);
+
+    FutureTask<InteractiveAuthenticationDetails> task = existingTask != null
+      ? existingTask
+      : ENTRIES.computeIfAbsent(identity, key -> new FutureTask<>(login::get));
+
+    // A no-op if another thread has already called run() on this task.
+    task.run();
+
+    return await(task);
+  }
+
+  /**
+   * Removes any entry that has completed, and is no longer useful: one that
+   * failed, or one whose session token has expired. An entry that is still
+   * in progress is never removed by this method.
+   */
+  private static void removeStaleEntries() {
+    ENTRIES.values().removeIf(InteractiveAuthenticationCache::isStale);
+  }
+
+  /**
+   * Returns {@code true} if {@code task} has completed, and its result is no
+   * longer usable: either it failed, or the session token it produced has
+   * expired.
+   */
+  private static boolean isStale(FutureTask<InteractiveAuthenticationDetails> task) {
+    if (!task.isDone())
+      return false;
+
+    InteractiveAuthenticationDetails details = getIfSuccessful(task);
+
+    return details == null
+      || !OffsetDateTime.now().isBefore(details.getExpirationTime());
+  }
+
+  /**
+   * Returns the result of a completed {@code task}, or {@code null} if it
+   * completed with an exception. Unlike {@link #await(FutureTask)}, this
+   * method does not propagate that exception to the caller.
+   */
+  private static InteractiveAuthenticationDetails getIfSuccessful(
+      FutureTask<InteractiveAuthenticationDetails> task) {
+    try {
+      return task.get();
+    }
+    catch (ExecutionException executionException) {
+      return null;
+    }
+    catch (InterruptedException interruptedException) {
+      throw new IllegalStateException(interruptedException);
+    }
+  }
+
+  /**
+   * Returns the result of {@code task}, blocking the calling thread until it
+   * completes. Unlike {@link #getIfSuccessful(FutureTask)}, this method
+   * rethrows the cause of a failed {@code task} to the caller.
+   */
+  private static InteractiveAuthenticationDetails await(
+      FutureTask<InteractiveAuthenticationDetails> task) {
+    try {
+      return task.get();
+    }
+    catch (ExecutionException executionException) {
+      Throwable cause = executionException.getCause();
+
+      if (cause instanceof Error)
+        throw (Error) cause;
+      else if (cause instanceof RuntimeException)
+        throw (RuntimeException) cause;
+      else
+        throw new IllegalStateException(cause);
+    }
+    catch (InterruptedException interruptedException) {
+      throw new IllegalStateException(interruptedException);
+    }
+  }
+}

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/authentication/InteractiveAuthenticationDetails.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/authentication/InteractiveAuthenticationDetails.java
@@ -50,6 +50,7 @@ import java.security.KeyPair;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
+import java.time.OffsetDateTime;
 import java.util.Map;
 
 /**
@@ -102,6 +103,14 @@ public class InteractiveAuthenticationDetails
   private final PemData privateKey;
 
   /**
+   * Time at which the {@code sessionToken} passed to the constructor expires,
+   * per its "exp" claim. This class does not refresh or renew the session
+   * token that it wraps, so a caller that caches an instance of this class
+   * should treat it as invalid once this time has passed.
+   */
+  private final OffsetDateTime expirationTime;
+
+  /**
    * Constructs of provider of interactive authentication details. This
    * constructor extracts details from the claims of a {@code sessionToken},
    * which is assumed to a JSON Web Token (JWT) encoding.
@@ -127,6 +136,16 @@ public class InteractiveAuthenticationDetails
     this.tenantId = tokenClaims.get("tenant");
     this.userId = tokenClaims.get("sub");
     this.keyId = "ST$" + sessionToken;
+    this.expirationTime = JsonWebTokenParser.parseExp(sessionToken);
+  }
+
+  /**
+   * Returns the time at which the session token wrapped by this object
+   * expires.
+   * @return The expiration time of the session token. Not null.
+   */
+  OffsetDateTime getExpirationTime() {
+    return expirationTime;
   }
 
   @Override

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciConfigurationParameters.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciConfigurationParameters.java
@@ -103,6 +103,10 @@ public final class OciConfigurationParameters {
       .addParameter("OCI_INTERACTIVE_TIMEOUT", INTERACTIVE_TIMEOUT,
          DEFAULT_INTERACTIVE_TIMEOUT_MINUTES,
          s -> parsePositiveInt("OCI_INTERACTIVE_TIMEOUT", s))
+      // Not a credential: distinguishes otherwise-identical INTERACTIVE
+      // logins so that one is not reused in place of the other. See the
+      // javadoc of AuthenticationDetailsFactory.USERNAME.
+      .addParameter("OCI_USERNAME", USERNAME)
       .build();
 
   /**

--- a/ojdbc-provider-oci/src/test/java/oracle/jdbc/provider/oci/AuthenticationDetailsFactoryTest.java
+++ b/ojdbc-provider-oci/src/test/java/oracle/jdbc/provider/oci/AuthenticationDetailsFactoryTest.java
@@ -43,12 +43,14 @@ import oracle.jdbc.provider.TestProperties;
 import oracle.jdbc.provider.factory.Resource;
 import oracle.jdbc.provider.oci.authentication.AuthenticationDetailsFactory;
 import oracle.jdbc.provider.oci.authentication.AuthenticationMethod;
+import oracle.jdbc.provider.parameter.Parameter;
 import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.provider.parameter.ParameterSetBuilder;
 import org.junit.jupiter.api.Test;
 
 import static oracle.jdbc.provider.TestProperties.getOrAbort;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Verifies {@link AuthenticationDetailsFactory} */
@@ -121,6 +123,83 @@ public class AuthenticationDetailsFactoryTest {
     TestProperties.abortIfNotEqual(OciTestProperty.OCI_INTERACTIVE, "true");
     verifyAuthenticationDetails(
             buildParameterSet(AuthenticationMethod.INTERACTIVE).build());
+  }
+
+  /**
+   * <p>
+   * Verifies that two requests configured with the same
+   * {@link AuthenticationMethod#INTERACTIVE} identity reuse a single, cached
+   * login, rather than each triggering their own browser-based login. This
+   * is the scenario of a Database Tools Connection and its embedded password
+   * and wallet secrets, each requesting authentication independently, but
+   * expecting to share one login between them.
+   * </p><p>
+   * This test only performs one browser-based login: if authentication were
+   * not cached, the second {@code request()} call below would prompt for a
+   * second login, and the two resulting objects would not be the same
+   * instance.
+   * </p>
+   */
+  @Test
+  public void testInteractiveAuthenticationIsCached() {
+    TestProperties.abortIfNotEqual(OciTestProperty.OCI_INTERACTIVE, "true");
+
+    ParameterSet parameterSet =
+      buildParameterSet(AuthenticationMethod.INTERACTIVE).build();
+
+    AbstractAuthenticationDetailsProvider firstLogin =
+      AuthenticationDetailsFactory.getInstance()
+        .request(parameterSet)
+        .getContent();
+
+    AbstractAuthenticationDetailsProvider secondLogin =
+      AuthenticationDetailsFactory.getInstance()
+        .request(parameterSet)
+        .getContent();
+
+    assertSame(firstLogin, secondLogin);
+  }
+
+  /**
+   * <p>
+   * Verifies that a cached {@link AuthenticationMethod#INTERACTIVE} login is
+   * reused even when a second request carries additional, resource-specific
+   * parameters that the first request did not have, such as the OCID of a
+   * secret or a Database Tools Connection. Such parameters play no role in
+   * authentication, and must not cause a cached login to be missed.
+   * </p><p>
+   * As with {@link #testInteractiveAuthenticationIsCached()}, this test only
+   * performs one browser-based login.
+   * </p>
+   */
+  @Test
+  public void testInteractiveAuthenticationCacheIgnoresResourceParameters() {
+    TestProperties.abortIfNotEqual(OciTestProperty.OCI_INTERACTIVE, "true");
+
+    Parameter<String> resourceSpecificParameter = Parameter.create();
+
+    ParameterSet parameterSet =
+      buildParameterSet(AuthenticationMethod.INTERACTIVE).build();
+
+    ParameterSet parameterSetWithResourceParameter =
+      parameterSet.copyBuilder()
+        .add(
+          "Test resource-specific parameter",
+          resourceSpecificParameter,
+          "ocid1.vaultsecret.oc1..example")
+        .build();
+
+    AbstractAuthenticationDetailsProvider firstLogin =
+      AuthenticationDetailsFactory.getInstance()
+        .request(parameterSet)
+        .getContent();
+
+    AbstractAuthenticationDetailsProvider secondLogin =
+      AuthenticationDetailsFactory.getInstance()
+        .request(parameterSetWithResourceParameter)
+        .getContent();
+
+    assertSame(firstLogin, secondLogin);
   }
 
   /**

--- a/ojdbc-provider-oci/src/test/java/oracle/jdbc/provider/oci/authentication/InteractiveAuthenticationCacheTest.java
+++ b/ojdbc-provider-oci/src/test/java/oracle/jdbc/provider/oci/authentication/InteractiveAuthenticationCacheTest.java
@@ -1,0 +1,302 @@
+/*
+ ** Copyright (c) 2026 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.jdbc.provider.oci.authentication;
+
+import com.oracle.bmc.Region;
+import oracle.jdbc.provider.parameter.Parameter;
+import oracle.jdbc.provider.parameter.ParameterSet;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies {@link InteractiveAuthenticationCache} using synthetic
+ * {@link Supplier} logins, rather than real, browser-based interactive
+ * authentication.
+ */
+public class InteractiveAuthenticationCacheTest {
+
+  /** A parameter used only to build distinct test identities */
+  private static final Parameter<String> TEST_ID = Parameter.create();
+
+  /**
+   * Verifies that a second call for the same identity reuses the result of
+   * the first call, rather than invoking {@code login} again.
+   */
+  @Test
+  public void testCachesSuccessfulLogin() {
+    ParameterSet identity = identity("testCachesSuccessfulLogin");
+    AtomicInteger loginCount = new AtomicInteger(0);
+
+    Supplier<InteractiveAuthenticationDetails> login = () -> {
+      loginCount.incrementAndGet();
+      return fakeDetails(OffsetDateTime.now().plusHours(1));
+    };
+
+    InteractiveAuthenticationDetails first =
+      InteractiveAuthenticationCache.get(identity, login);
+    InteractiveAuthenticationDetails second =
+      InteractiveAuthenticationCache.get(identity, login);
+
+    assertSame(first, second);
+    assertEquals(1, loginCount.get());
+  }
+
+  /**
+   * Verifies that two different identities are cached independently: each
+   * invokes its own {@code login}, and neither result is reused for the
+   * other.
+   */
+  @Test
+  public void testDifferentIdentitiesAreCachedIndependently() {
+    ParameterSet identityA = identity("testDifferentIdentitiesAreCachedIndependently-A");
+    ParameterSet identityB = identity("testDifferentIdentitiesAreCachedIndependently-B");
+
+    InteractiveAuthenticationDetails detailsA =
+      InteractiveAuthenticationCache.get(
+        identityA, () -> fakeDetails(OffsetDateTime.now().plusHours(1)));
+    InteractiveAuthenticationDetails detailsB =
+      InteractiveAuthenticationCache.get(
+        identityB, () -> fakeDetails(OffsetDateTime.now().plusHours(1)));
+
+    assertNotSame(detailsA, detailsB);
+
+    // Each identity still independently returns its own cached login.
+    assertSame(
+      detailsA,
+      InteractiveAuthenticationCache.get(identityA, InteractiveAuthenticationCacheTest::fail));
+    assertSame(
+      detailsB,
+      InteractiveAuthenticationCache.get(identityB, InteractiveAuthenticationCacheTest::fail));
+  }
+
+  /**
+   * <p>
+   * Verifies that a failed login is not cached: a following call for the
+   * same identity attempts a fresh login, rather than replaying the same
+   * exception indefinitely. A session timeout is an ordinary event that
+   * must be retryable with a fresh prompt, not a permanent failure.
+   * </p>
+   */
+  @Test
+  public void testFailedLoginIsNotCached() {
+    ParameterSet identity = identity("testFailedLoginIsNotCached");
+    AtomicInteger loginCount = new AtomicInteger(0);
+
+    Supplier<InteractiveAuthenticationDetails> login = () -> {
+      if (loginCount.incrementAndGet() == 1)
+        throw new IllegalStateException("Simulated login timeout");
+
+      return fakeDetails(OffsetDateTime.now().plusHours(1));
+    };
+
+    assertThrows(
+      IllegalStateException.class,
+      () -> InteractiveAuthenticationCache.get(identity, login));
+    assertEquals(1, loginCount.get());
+
+    InteractiveAuthenticationDetails details =
+      InteractiveAuthenticationCache.get(identity, login);
+
+    assertEquals(2, loginCount.get());
+
+    // The now-successful login is cached normally.
+    assertSame(details, InteractiveAuthenticationCache.get(identity, login));
+    assertEquals(2, loginCount.get());
+  }
+
+  /**
+   * Verifies that a cached login whose session token has expired is not
+   * reused: a following call for the same identity attempts a fresh login.
+   */
+  @Test
+  public void testExpiredLoginIsNotReused() {
+    ParameterSet identity = identity("testExpiredLoginIsNotReused");
+    AtomicInteger loginCount = new AtomicInteger(0);
+
+    InteractiveAuthenticationDetails expired =
+      InteractiveAuthenticationCache.get(identity, () -> {
+        loginCount.incrementAndGet();
+        // Expires immediately (in the past), so it is stale as soon as it
+        // is cached.
+        return fakeDetails(OffsetDateTime.now().minusSeconds(1));
+      });
+
+    InteractiveAuthenticationDetails fresh =
+      InteractiveAuthenticationCache.get(identity, () -> {
+        loginCount.incrementAndGet();
+        return fakeDetails(OffsetDateTime.now().plusHours(1));
+      });
+
+    assertNotSame(expired, fresh);
+    assertEquals(2, loginCount.get());
+
+    // The now-valid login is cached normally.
+    assertSame(
+      fresh,
+      InteractiveAuthenticationCache.get(identity, InteractiveAuthenticationCacheTest::fail));
+  }
+
+  /**
+   * Verifies that many threads requesting the same, not yet cached identity
+   * concurrently share a single login, rather than each triggering their
+   * own.
+   */
+  @Test
+  public void testConcurrentRequestsShareOneLogin() throws Exception {
+    ParameterSet identity = identity("testConcurrentRequestsShareOneLogin");
+    AtomicInteger loginCount = new AtomicInteger(0);
+
+    // Delays the login just long enough for multiple threads to reliably
+    // observe no cached value yet, and attempt to log in concurrently.
+    CountDownLatch allThreadsReady = new CountDownLatch(16);
+    Supplier<InteractiveAuthenticationDetails> login = () -> {
+      loginCount.incrementAndGet();
+      awaitLatch(allThreadsReady);
+      return fakeDetails(OffsetDateTime.now().plusHours(1));
+    };
+
+    ExecutorService executor = Executors.newFixedThreadPool(16);
+    try {
+      List<Future<InteractiveAuthenticationDetails>> futures =
+        IntStream.range(0, 16)
+          .mapToObj(i -> executor.submit(() -> {
+            allThreadsReady.countDown();
+            return InteractiveAuthenticationCache.get(identity, login);
+          }))
+          .collect(Collectors.toList());
+
+      List<InteractiveAuthenticationDetails> results = new ArrayList<>();
+      for (Future<InteractiveAuthenticationDetails> future : futures)
+        results.add(future.get(30, TimeUnit.SECONDS));
+
+      InteractiveAuthenticationDetails first = results.get(0);
+      for (InteractiveAuthenticationDetails result : results)
+        assertSame(first, result);
+
+      assertEquals(1, loginCount.get());
+    }
+    finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static void awaitLatch(CountDownLatch latch) {
+    boolean allThreadsBecameReady;
+    try {
+      allThreadsBecameReady = latch.await(30, TimeUnit.SECONDS);
+    }
+    catch (InterruptedException interruptedException) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(interruptedException);
+    }
+
+    if (! allThreadsBecameReady)
+      throw new IllegalStateException(
+        "Timed out waiting for all threads to become ready");
+  }
+
+  /**
+   * A login {@code Supplier} that fails the test if it is ever invoked
+   *
+   */
+  private static InteractiveAuthenticationDetails fail() {
+    throw new AssertionError(
+      "login should not be invoked: a cached value was expected");
+  }
+
+  /**
+   *  Returns a {@code ParameterSet} identifying a distinct test identity
+   * */
+  private static ParameterSet identity(String id) {
+    return ParameterSet.builder()
+      .add("id", TEST_ID, id)
+      .build();
+  }
+
+  /**
+   * Returns a synthetic {@link InteractiveAuthenticationDetails}, with a
+   * real, generated key pair, and a session token whose "exp" claim encodes
+   * the given {@code expirationTime}.
+   */
+  private static InteractiveAuthenticationDetails fakeDetails(
+      OffsetDateTime expirationTime) {
+
+    KeyPair keyPair;
+    try {
+      keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+    }
+    catch (NoSuchAlgorithmException noSuchAlgorithmException) {
+      throw new IllegalStateException(noSuchAlgorithmException);
+    }
+
+    String payload = String.format(
+      "{\"tenant\":\"test-tenant\",\"sub\":\"test-user\",\"exp\":%d}",
+      expirationTime.toEpochSecond());
+
+    String encodedPayload = Base64.getUrlEncoder().withoutPadding()
+      .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+
+    String sessionToken = "header." + encodedPayload + ".signature";
+
+    return new InteractiveAuthenticationDetails(
+      Region.EU_AMSTERDAM_1, sessionToken, keyPair);
+  }
+}


### PR DESCRIPTION
When using `AUTHENTICATION=OCI_INTERACTIVE`, every OCI resource request triggered its own browser-based login, even when several requests genuinely belonged to the same sign-in, for example, resolving a Database Tools Connection along with its embedded password and wallet secrets meant clicking through the login page three separate times instead of once. This PR adds a small, dedicated cache for interactive logins so that requests sharing the same identity reuse a single session for as long as it stays valid, instead of prompting again and again.

We also added a new option, `OCI_USERNAME`, that lets you manually tag a login as belonging to a specific identity. This matters for one specific case: if a password or wallet stored elsewhere in a config actually needs to log in as a different account than the rest of the config, setting `OCI_USERNAME` on it forces a separate login instead of wrongly reusing the cached one. This option already existed for one part of the codebase; we extended it to work everywhere.

This PR includes Tests as well.