### PR TITLE
Cache interactive Azure logins to avoid repeated browser/device-code prompts

### DIFF
--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -229,6 +229,23 @@ The user can provide an optional parameter `AUTHENTICATION` (case-ignored) which
 </tbody>
 </table>
 
+### Interactive Authentication Caching
+
+When `AUTHENTICATION=AZURE_INTERACTIVE` or `AUTHENTICATION=AZURE_DEVICE_CODE`
+(or `authenticationMethod=interactive` / `authenticationMethod=device-code` for
+[Resource Providers](#configuring-authentication-for-resource-providers)) is
+configured, a browser-based or device-code login is only prompted once for a given
+identity: any subsequent request that presents the same `AZURE_TENANT_ID`,
+`AZURE_CLIENT_ID`, and `AZURE_REDIRECT_URL` reuses the credential from that login,
+rather than prompting for another login. For example, a main configuration and an
+embedded [password](#password-json-object) or
+[wallet_location](#wallet_location-json-object) object configured with the same
+identity share a single login between them.
+
+Reuse relies on the Azure Identity library's own in-memory token caching, which
+automatically refreshes an access token before it expires without a new login. See
+[Token caching in the Azure Identity client library](https://github.com/Azure/azure-sdk-for-java/blob/azure-identity_1.18.0/sdk/identity/azure-identity/TOKEN_CACHING.md).
+
 ### DefaultAzureCredential
 
 The Azure SDK `DefaultAzureCredential` class tries the following flow in order to try to Authenticate an application:
@@ -810,13 +827,17 @@ with a username and password.
 <dt>device-code</dt>
 <dd>
 Authenticate interactively by logging in to an Azure account in a web browser.
-A browser link is output to the standard output stream.
+A browser link is output to the standard output stream. See
+<a href="#interactive-authentication-caching">Interactive Authentication Caching</a>
+for details on how a login may be reused across multiple resource requests.
 </dd>
 <dt>interactive</dt>
 <dd>
 Authenticate interactively by logging in to a cloud account with your
 default web browser. The browser window is opened automatically. The optional
 <code>tenantId</code> parameter may be configured to target a specific tenant.
+See <a href="#interactive-authentication-caching">Interactive Authentication Caching</a>
+for details on how a login may be reused across multiple resource requests.
 </dd>
 <dt>auto-detect</dt>
 <dd>

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/authentication/InteractiveTokenCredentialCache.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/authentication/InteractiveTokenCredentialCache.java
@@ -1,0 +1,116 @@
+/*
+ ** Copyright (c) 2026 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.jdbc.provider.azure.authentication;
+
+import com.azure.core.credential.TokenCredential;
+import oracle.jdbc.provider.parameter.ParameterSet;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+
+/**
+ * <p>
+ * A cache of {@link TokenCredential} objects, keyed on the identity of an
+ * {@link AzureAuthenticationMethod#INTERACTIVE} or
+ * {@link AzureAuthenticationMethod#DEVICE_CODE} login (see
+ * {@link TokenCredentialFactory#INTERACTIVE_IDENTITY_PARAMETERS}).
+ * </p><p>
+ * Both of these methods require a human to complete a login with a web
+ * browser. Building a fresh, never-used credential for every resource
+ * request that needs one would mean prompting that human again and again for
+ * what is, from their perspective, a single sign-in.
+ * </p><p>
+ * An Azure {@code TokenCredential} does not perform a login when it is
+ * constructed: authentication happens lazily, the first time something
+ * calls {@link TokenCredential#getToken} on it. From that point on, the
+ * credential manages caching and refreshing its own access token
+ * internally, in memory, for as long as it continues to be used; this is
+ * documented, default behavior of the Azure Identity library, requiring no
+ * opt-in configuration, for both {@link AzureAuthenticationMethod#INTERACTIVE}
+ * and {@link AzureAuthenticationMethod#DEVICE_CODE} credentials. See
+ * <a href="https://github.com/Azure/azure-sdk-for-java/blob/azure-identity_1.18.0/sdk/identity/azure-identity/TOKEN_CACHING.md">
+ * Token caching in the Azure Identity client library
+ * </a>: <i>"In-memory token caching is the default option provided by the
+ * Azure Identity library... With in-memory token caching, the library first
+ * determines if a valid access token for the requested resource is already
+ * stored in memory. If a valid token is found, it's returned to the app
+ * without the need to make another request to Microsoft Entra ID."</i>
+ * </p><p>
+ * This means the cache in this class only needs to ensure that requests
+ * sharing the same identity are handed the exact same {@code TokenCredential}
+ * instance, rather than each getting its own, never-yet-authenticated one
+ * that would independently prompt for a fresh login on first use. There is
+ * no need for this cache to track an expiration itself, or to distinguish a
+ * successful login from a failed one: the credential is not actually used
+ * until later, outside of this cache's control.
+ * </p>
+ */
+final class InteractiveTokenCredentialCache {
+
+  /**
+   * Cached credentials, keyed on identity.
+   * */
+  private static final ConcurrentMap<ParameterSet, TokenCredential> ENTRIES =
+    new ConcurrentHashMap<>();
+
+  private InteractiveTokenCredentialCache() {}
+
+  /**
+   * <p>
+   * Returns a cached {@code TokenCredential} for the given {@code identity},
+   * or invokes {@code credentialSupplier} to build one if none is cached.
+   * </p><p>
+   * This is a thread safe method: if multiple threads call this method
+   * concurrently with an equal {@code identity}, {@code credentialSupplier}
+   * is guaranteed to be invoked by at most one of them, and all of them
+   * receive the same resulting {@code TokenCredential}.
+   * </p>
+   *
+   * @param identity Identifies the credential to return. Not null.
+   * @param credentialSupplier Builds a new credential. Only invoked when no
+   * credential is already cached for {@code identity}. Not null.
+   * @return A {@code TokenCredential} for {@code identity}, either cached or
+   * freshly built by {@code credentialSupplier}. Not null.
+   */
+  static TokenCredential get(
+      ParameterSet identity, Supplier<TokenCredential> credentialSupplier) {
+    return ENTRIES.computeIfAbsent(identity, identityKey -> credentialSupplier.get());
+  }
+}

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/authentication/TokenCredentialFactory.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/authentication/TokenCredentialFactory.java
@@ -45,7 +45,11 @@ import oracle.jdbc.provider.factory.Resource;
 import oracle.jdbc.provider.factory.ResourceFactory;
 import oracle.jdbc.provider.parameter.Parameter;
 import oracle.jdbc.provider.parameter.ParameterSet;
+import oracle.jdbc.provider.parameter.ParameterSetBuilder;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import static com.azure.core.util.Configuration.*;
@@ -113,6 +117,26 @@ public final class TokenCredentialFactory
    */
   public static final Parameter<String> REDIRECT_URL = Parameter.create();
 
+  /**
+   * <p>
+   * The parameters that identify a previously resolved
+   * {@link AzureAuthenticationMethod#INTERACTIVE} or
+   * {@link AzureAuthenticationMethod#DEVICE_CODE} login eligible for reuse.
+   * Two {@code ParameterSet} instances that agree on the values of every
+   * parameter in this list are considered to represent the same login,
+   * regardless of any other, resource-specific parameters that either
+   * {@code ParameterSet} might also carry.
+   * </p><p>
+   * This list includes every parameter that {@link #interactiveCredentials}
+   * and {@link #deviceCodeCredentials} read: {@link #CLIENT_ID},
+   * {@link #TENANT_ID}, and {@link #REDIRECT_URL} (the latter is only read
+   * for {@code INTERACTIVE}, but including it here is harmless for
+   * {@code DEVICE_CODE}, where it is simply absent from every identity).
+   * </p>
+   */
+  static final List<Parameter<?>> INTERACTIVE_IDENTITY_PARAMETERS =
+          List.of(AUTHENTICATION_METHOD, CLIENT_ID, TENANT_ID, REDIRECT_URL);
+
   private static final TokenCredentialFactory INSTANCE
       = new TokenCredentialFactory();
 
@@ -126,12 +150,74 @@ public final class TokenCredentialFactory
     return INSTANCE;
   }
 
+  /**
+   * {@inheritDoc}
+   * <p>
+   * When the configured {@link #AUTHENTICATION_METHOD} is
+   * {@link AzureAuthenticationMethod#INTERACTIVE} or
+   * {@link AzureAuthenticationMethod#DEVICE_CODE}, the returned resource may
+   * wrap a previously cached {@code TokenCredential}, reused from another
+   * request that presented the same {@link #INTERACTIVE_IDENTITY_PARAMETERS}.
+   * See {@link InteractiveTokenCredentialCache}.
+   * </p>
+   */
   @Override
   public Resource<TokenCredential> request(ParameterSet parameterSet) {
-    TokenCredential tokenCredential = getCredential(parameterSet);
-    // TODO: Access tokens expire. Does a TokenCredential internally cache one?
-    //   If so, then return an expiring resource.
+
+    AzureAuthenticationMethod authenticationMethod =
+      parameterSet.contains(AUTHENTICATION_METHOD)
+        ? parameterSet.getRequired(AUTHENTICATION_METHOD)
+        : AzureAuthenticationMethod.DEFAULT;
+
+    TokenCredential tokenCredential =
+      authenticationMethod == AzureAuthenticationMethod.INTERACTIVE
+        || authenticationMethod == AzureAuthenticationMethod.DEVICE_CODE
+      ? InteractiveTokenCredentialCache.get(
+          interactiveIdentity(parameterSet),
+          () -> getCredential(authenticationMethod, parameterSet))
+      : getCredential(authenticationMethod, parameterSet);
+
     return Resource.createPermanentResource(tokenCredential, true);
+  }
+
+  /**
+   * <p>
+   * Returns a {@code ParameterSet} containing only the values of
+   * {@link #INTERACTIVE_IDENTITY_PARAMETERS} from the given
+   * {@code parameterSet}. This projection is used only as the cache key
+   * passed to {@link InteractiveTokenCredentialCache#get(ParameterSet, java.util.function.Supplier)}:
+   * two requests are considered the same login if and only if they agree on
+   * this projection. Resource-specific parameters play no role in
+   * authentication, and would otherwise cause every distinct resource
+   * request to miss the cache, even when made with the same identity.
+   * </p><p>
+   * This projection is not used as the input to building a fresh credential
+   * on a cache miss: {@code request(ParameterSet)} passes the original,
+   * unprojected {@code parameterSet} for that purpose instead, since
+   * {@link #getCredential(AzureAuthenticationMethod, ParameterSet)} may read
+   * parameters that this projection excludes.
+   *
+   * @param parameterSet Parameters of a resource request. Not null.
+   * @return The {@link #INTERACTIVE_IDENTITY_PARAMETERS} projection of
+   * {@code parameterSet}. Not null.
+   */
+  private static ParameterSet interactiveIdentity(ParameterSet parameterSet) {
+    ParameterSetBuilder builder = ParameterSet.builder();
+
+    for (Parameter<?> parameter : INTERACTIVE_IDENTITY_PARAMETERS)
+      copyValue(builder, parameterSet, parameter);
+
+    return builder.build();
+  }
+
+  /**
+   * Copies the value of a single {@code parameter} from {@code source} into {@code builder}, if present.
+   */
+  private static <T> void copyValue(
+      ParameterSetBuilder builder, ParameterSet source, Parameter<T> parameter) {
+
+    if (source.contains(parameter))
+      builder.add(source.getName(parameter), parameter, source.getOptional(parameter));
   }
 
   /**
@@ -139,14 +225,12 @@ public final class TokenCredentialFactory
    * used are configured by the parameters of the given {@code parameters}.
    * Supported parameters are defined by the class variables in
    * {@link TokenCredentialFactory}.
+   * @param authenticationMethod Method of authentication to use. Not null.
    * @param parameterSet parameters that configure credentials. Not null.
    * @return Credentials configured by parameters
    */
-  private static TokenCredential getCredential(ParameterSet parameterSet) {
-
-    AzureAuthenticationMethod authenticationMethod =
-      parameterSet.contains(AUTHENTICATION_METHOD)
-        ? parameterSet.getRequired(AUTHENTICATION_METHOD) : AzureAuthenticationMethod.DEFAULT;
+  private static TokenCredential getCredential(
+      AzureAuthenticationMethod authenticationMethod, ParameterSet parameterSet) {
 
     switch (authenticationMethod) {
       case DEFAULT:

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/authentication/InteractiveTokenCredentialCacheTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/authentication/InteractiveTokenCredentialCacheTest.java
@@ -1,0 +1,273 @@
+/*
+ ** Copyright (c) 2026 Oracle and/or its affiliates.
+ **
+ ** The Universal Permissive License (UPL), Version 1.0
+ **
+ ** Subject to the condition set forth below, permission is hereby granted to any
+ ** person obtaining a copy of this software, associated documentation and/or data
+ ** (collectively the "Software"), free of charge and under any and all copyright
+ ** rights in the Software, and any and all patent rights owned or freely
+ ** licensable by each licensor hereunder covering either (i) the unmodified
+ ** Software as contributed to or provided by such licensor, or (ii) the Larger
+ ** Works (as defined below), to deal in both
+ **
+ ** (a) the Software, and
+ ** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ ** one is included with the Software (each a "Larger Work" to which the Software
+ ** is contributed by such licensors),
+ **
+ ** without restriction, including without limitation the rights to copy, create
+ ** derivative works of, display, perform, and distribute the Software and make,
+ ** use, sell, offer for sale, import, export, have made, and have sold the
+ ** Software and the Larger Work(s), and to sublicense the foregoing rights on
+ ** either these or other terms.
+ **
+ ** This license is subject to the following condition:
+ ** The above copyright notice and either this complete permission notice or at
+ ** a minimum a reference to the UPL must be included in all copies or
+ ** substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ ** SOFTWARE.
+ */
+
+package oracle.jdbc.provider.azure.authentication;
+
+import com.azure.core.credential.TokenCredential;
+import oracle.jdbc.provider.parameter.Parameter;
+import oracle.jdbc.provider.parameter.ParameterSet;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies {@link InteractiveTokenCredentialCache} using synthetic
+ * {@link Supplier} credential builders, rather than a real, browser-based or
+ * device-code login.
+ */
+public class InteractiveTokenCredentialCacheTest {
+
+  /**
+   * A parameter used only to build distinct test identities
+   */
+  private static final Parameter<String> TEST_ID = Parameter.create();
+
+  /**
+   * Verifies that a second call for the same identity reuses the credential
+   * built by the first call, rather than building a new one.
+   */
+  @Test
+  public void testCachesCredentialForSameIdentity() {
+    ParameterSet identity = identity("testCachesCredentialForSameIdentity");
+    AtomicInteger buildCount = new AtomicInteger(0);
+
+    Supplier<TokenCredential> credentialSupplier = () -> {
+      buildCount.incrementAndGet();
+      return fakeCredential();
+    };
+
+    TokenCredential first =
+      InteractiveTokenCredentialCache.get(identity, credentialSupplier);
+    TokenCredential second =
+      InteractiveTokenCredentialCache.get(identity, credentialSupplier);
+
+    assertSame(first, second);
+    assertEquals(1, buildCount.get());
+  }
+
+  /**
+   * Verifies that two different identities are cached independently: each
+   * builds its own credential, and neither result is reused for the other.
+   */
+  @Test
+  public void testDifferentIdentitiesAreCachedIndependently() {
+    ParameterSet identityA = identity("testDifferentIdentitiesAreCachedIndependently-A");
+    ParameterSet identityB = identity("testDifferentIdentitiesAreCachedIndependently-B");
+
+    TokenCredential credentialA =
+      InteractiveTokenCredentialCache.get(
+        identityA, InteractiveTokenCredentialCacheTest::fakeCredential);
+    TokenCredential credentialB =
+      InteractiveTokenCredentialCache.get(
+        identityB, InteractiveTokenCredentialCacheTest::fakeCredential);
+
+    assertNotSame(credentialA, credentialB);
+
+    // Each identity still independently returns its own cached credential.
+    assertSame(
+      credentialA,
+      InteractiveTokenCredentialCache.get(identityA, InteractiveTokenCredentialCacheTest::fail));
+    assertSame(
+      credentialB,
+      InteractiveTokenCredentialCache.get(identityB, InteractiveTokenCredentialCacheTest::fail));
+  }
+
+  /**
+   * <p>
+   * Verifies that a failed attempt to build a credential is not cached: a
+   * following call for the same identity attempts to build a fresh one,
+   * rather than replaying the same exception indefinitely.
+   * </p><p>
+   * Building an Azure {@code TokenCredential} does not itself perform
+   * authentication (it happens lazily, later, when something calls
+   * {@link TokenCredential#getToken}), so a failure here represents a
+   * configuration error (such as a missing client ID) rather than a failed
+   * login. Even so, such a failure should not be cached indefinitely.
+   * </p>
+   */
+  @Test
+  public void testBuildFailureIsNotCached() {
+    ParameterSet identity = identity("testBuildFailureIsNotCached");
+    AtomicInteger buildCount = new AtomicInteger(0);
+
+    Supplier<TokenCredential> credentialSupplier = () -> {
+      if (buildCount.incrementAndGet() == 1)
+        throw new IllegalStateException("Simulated configuration error");
+
+      return fakeCredential();
+    };
+
+    assertThrows(
+      IllegalStateException.class,
+      () -> InteractiveTokenCredentialCache.get(identity, credentialSupplier));
+    assertEquals(1, buildCount.get());
+
+    TokenCredential credential =
+      InteractiveTokenCredentialCache.get(identity, credentialSupplier);
+
+    assertEquals(2, buildCount.get());
+
+    // The now-successful credential is cached normally.
+    assertSame(
+      credential, InteractiveTokenCredentialCache.get(identity, credentialSupplier));
+    assertEquals(2, buildCount.get());
+  }
+
+  /**
+   * Verifies that many threads requesting the same, not yet cached identity
+   * concurrently share a single credential, rather than each building their
+   * own.
+   */
+  @Test
+  public void testConcurrentRequestsShareOneCredential() throws Exception {
+    ParameterSet identity = identity("testConcurrentRequestsShareOneCredential");
+    AtomicInteger buildCount = new AtomicInteger(0);
+
+    // Delays the build just long enough for multiple threads to reliably
+    // observe no cached value yet, and attempt to build concurrently.
+    CountDownLatch allThreadsReady = new CountDownLatch(16);
+    Supplier<TokenCredential> credentialSupplier = () -> {
+      buildCount.incrementAndGet();
+      awaitLatch(allThreadsReady);
+      return fakeCredential();
+    };
+
+    ExecutorService executor = Executors.newFixedThreadPool(16);
+    try {
+      List<Future<TokenCredential>> futures =
+        IntStream.range(0, 16)
+          .mapToObj(i -> executor.submit(() -> {
+            allThreadsReady.countDown();
+            return InteractiveTokenCredentialCache.get(identity, credentialSupplier);
+          }))
+          .collect(Collectors.toList());
+
+      List<TokenCredential> results = new ArrayList<>();
+      for (Future<TokenCredential> future : futures)
+        results.add(future.get(30, TimeUnit.SECONDS));
+
+      TokenCredential first = results.get(0);
+      for (TokenCredential result : results)
+        assertSame(first, result);
+
+      assertEquals(1, buildCount.get());
+    }
+    finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static void awaitLatch(CountDownLatch latch) {
+    boolean allThreadsBecameReady;
+    try {
+      allThreadsBecameReady = latch.await(30, TimeUnit.SECONDS);
+    }
+    catch (InterruptedException interruptedException) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(interruptedException);
+    }
+
+    if (! allThreadsBecameReady)
+      throw new IllegalStateException(
+        "Timed out waiting for all threads to become ready");
+  }
+
+  /** A credential {@code Supplier} that fails the test if it is ever invoked */
+  private static TokenCredential fail() {
+    throw new AssertionError(
+      "credential should not be built: a cached value was expected");
+  }
+
+  /**
+   * Returns a {@code ParameterSet} identifying a distinct test identity
+   */
+  private static ParameterSet identity(String id) {
+    return ParameterSet.builder()
+      .add("id", TEST_ID, id)
+      .build();
+  }
+
+  /**
+   * Guarantees each {@link #fakeCredential()} call is distinguishable; see below.
+   */
+  private static final AtomicInteger FAKE_CREDENTIAL_COUNT = new AtomicInteger(0);
+
+  /**
+   * <p>
+   * Returns a synthetic {@link TokenCredential} that never actually attempts
+   * to acquire a token: {@link TokenCredential#getToken} always errors,
+   * since no test in this class needs it to succeed. The purpose of this
+   * method is only to verify that distinct instances are correctly cached
+   * and reused, not to exercise real Azure authentication.
+   * </p><p>
+   * The returned lambda captures a value unique to this call
+   * ({@link #FAKE_CREDENTIAL_COUNT}), so that two separate calls to this
+   * method always produce two distinguishable ({@code assertNotSame})
+   * instances. This is deliberate, and not just for a distinct error
+   * message: a <em>non</em>-capturing lambda (or method reference) may be
+   * cached and reused by the JVM across separate invocations of the
+   * enclosing method, since it would have no state of its own to
+   * distinguish one invocation from another, which would silently defeat
+   * tests in this class that rely on instance identity. Capturing a value
+   * here removes that risk without depending on this method being written
+   * one particular way (e.g. as an anonymous class instead of a lambda),
+   * since an automatic code-style cleanup could otherwise undo that later.
+   * </p>
+   */
+  private static TokenCredential fakeCredential() {
+    int id = FAKE_CREDENTIAL_COUNT.incrementAndGet();
+    return requestContext -> Mono.error(new UnsupportedOperationException(
+      "getToken() is not supported by this synthetic test credential (#" + id + ")"));
+  }
+}


### PR DESCRIPTION
When using interactive or device-code authentication, every Azure resource request built its own credential, even when several requests genuinely belonged to the same sign-in. For example, a main configuration along with an embedded password or wallet secret meant logging in multiple times instead of once. This PR adds a small, dedicated cache so that requests sharing the same identity reuse a single credential instead of building a new one each time.