### PR TITLE
Fix OSON serialization for empty collection fields

### DIFF
--- a/ojdbc-provider-jackson-oson/src/main/java/oracle/jdbc/provider/oson/OsonGenerator.java
+++ b/ojdbc-provider-jackson-oson/src/main/java/oracle/jdbc/provider/oson/OsonGenerator.java
@@ -174,16 +174,12 @@ public class OsonGenerator extends GeneratorBase {
    */
   @Override
   public void writeEndArray() throws IOException {
-    int status = _writeContext.writeValue();
-    if(status != _writeContext.STATUS_OK_AFTER_COMMA) {
-      _reportError("error: expecting end array");
-    }
     if (!_writeContext.inArray()) {
       _reportError("Current context not an ARRAY but " + _writeContext.getTypeDesc());
     }
     logger.log(Level.FINEST, "writeEndArray");
     gen.writeEnd();
-    _writeContext = _writeContext.getParent();
+    _writeContext = _writeContext.clearAndGetParent();
   }
 
   /**
@@ -206,16 +202,16 @@ public class OsonGenerator extends GeneratorBase {
    */
   @Override
   public void writeEndObject() throws IOException {
+    if (!_writeContext.inObject()) {
+      _reportError("Current context not an OBJECT but " + _writeContext.getTypeDesc());
+    }
     int status = _writeContext.writeValue();
     if (status != JsonWriteContext.STATUS_EXPECT_NAME) {
       _reportError("error: expecting end object");
     }
-    if (!_writeContext.inObject()) {
-      _reportError("Current context not an OBJECT but " + _writeContext.getTypeDesc());
-    }
     logger.log(Level.FINEST, "writeEndObject");
     gen.writeEnd();
-    _writeContext = _writeContext.getParent();
+    _writeContext = _writeContext.clearAndGetParent();
   }
 
   /**


### PR DESCRIPTION
This PR addresses issue #151 , where serializing a POJO containing  an empty list could fail with `JsonGenerationException: error: expecting end array.`
The problem was in `OsonGenerator.writeEndArray()`. When Jackson closed an array without writing an element, the generator tried to advance the array context as if another value were being written. For an empty array, this produced an invalid context state and caused the generator to report that it was still expecting an array value.

Tests were added for null list properties, empty list, non-empty lists, null objects, nested objects and incomplete objects.